### PR TITLE
release-core → main (0.0.26): auto-update migration, starfield, Settings accordions, Pro plan, DevTools-off

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,3 +103,15 @@ jobs:
           npx electron-builder --mac \
             -c.dmg.artifactName='OffGrid-${version}.${ext}' \
             --publish always
+      - name: Migrate legacy Pro update channel (publish pro-mac.yml)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          # Older Pro builds poll a SEPARATE channel (pro-mac.yml); the single build
+          # now publishes only the default latest-mac.yml. Upload a copy as
+          # pro-mac.yml (identical - same signed zip + version) so those installs see
+          # this release, auto-update, and land on the default channel. After that
+          # they follow latest-mac.yml. One-time bridge so no Pro user is orphaned.
+          cp dist/latest-mac.yml dist/pro-mac.yml
+          gh release upload "v$VERSION" dist/pro-mac.yml --clobber

--- a/e2e/tour.spec.ts
+++ b/e2e/tour.spec.ts
@@ -52,20 +52,30 @@ test('Models: merged tab + use-cases + import', async () => {
 
 test('Settings: setup, resource modes, storage, data & privacy all render', async () => {
   await nav('Settings');
+  // Sections are collapsed accordions — the titles (headings) are always visible;
+  // expand a card to reveal its body before asserting the body content.
   await expect(page.getByRole('heading', { name: 'Setup & health' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Data & privacy' })).toBeVisible();
+
+  await page.getByRole('button', { name: /Setup & health/ }).click(); // expand
   await expect(page.getByText('Configure it for me')).toBeVisible();
   // The resource-mode selector now lives inside the Configure card.
   for (const m of ['Conservative', 'Balanced', 'Extreme']) {
     // The mode button's accessible name includes its description, so match by substring.
     await expect(page.getByRole('button', { name: m }).first()).toBeVisible();
   }
-  await expect(page.getByRole('heading', { name: 'Data & privacy' })).toBeVisible();
+
+  await page.getByRole('button', { name: /Data & privacy/ }).click(); // expand
   await expect(page.getByText('Screen captures')).toBeVisible();
   await expect(page.getByText('Your data on this device')).toBeVisible();
 });
 
 test('Resource mode is selectable (Conservative)', async () => {
+  // Ensure the Setup & health accordion is expanded (the modes live in its body).
   const cons = page.getByRole('button', { name: 'Conservative' }).first();
+  if (!(await cons.isVisible().catch(() => false))) {
+    await page.getByRole('button', { name: /Setup & health/ }).click();
+  }
   await cons.click();
   await expect(cons).toHaveAttribute('aria-pressed', 'true');
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -82,7 +82,8 @@ function createWindow(): void {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false, // REQUIRED for IPC
       contextIsolation: true,
-      plugins: true // Chromium's built-in PDF viewer (chat attachment viewer) needs this
+      plugins: true, // Chromium's built-in PDF viewer (chat attachment viewer) needs this
+      devTools: is.dev // no inspector in the packaged/production build (tamper-proofing)
     }
   })
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -23,6 +23,7 @@ import { NotificationProvider, useNotifications } from './hooks/useNotifications
 import { ReprocessingProvider, useReprocessing } from './hooks/useReprocessing';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { GridBackdrop } from './components/ui/grid-backdrop';
+import { StarfieldBackdrop } from './components/ui/starfield-backdrop';
 import { Sidebar, SidebarBody } from './components/ui/sidebar';
 import { NavThemeToggle } from './components/ThemeToggle';
 import { motion, AnimatePresence } from 'motion/react';
@@ -562,8 +563,10 @@ function AppContent() {
           )}
         </button>
       )}
-      {/* Background — flat Off Grid terminal grid (theme-aware) */}
+      {/* Background — flat Off Grid terminal grid (theme-aware), with a dark-mode
+          starfield + periodic shooting star layered on top. */}
       <GridBackdrop className="z-0" />
+      <StarfieldBackdrop className="z-0" />
 
       <div className="flex h-full relative z-10">
         {/* Aceternity Sidebar */}

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -328,3 +328,50 @@ code {
     display: none;
   }
 }
+/* Starry-night backdrop (dark mode only): a periodic emerald shooting star that
+   streaks across the upper area, layered over the terminal grid. Static star dots
+   live on StarfieldBackdrop; this is just the animation. Pure CSS, no deps. */
+@keyframes og-shooting-star {
+  0%   { transform: translate3d(0, 0, 0) rotate(32deg); opacity: 0; }
+  4%   { opacity: 1; }
+  16%  { opacity: 1; }
+  20%  { transform: translate3d(900px, 560px, 0) rotate(32deg); opacity: 0; }
+  100% { transform: translate3d(900px, 560px, 0) rotate(32deg); opacity: 0; }
+}
+.og-shooting-star {
+  position: absolute;
+  top: 7%;
+  left: 10%;
+  width: 88px;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(52, 211, 153, 0.9), rgba(52, 211, 153, 0));
+  filter: drop-shadow(0 0 6px rgba(52, 211, 153, 0.45));
+  opacity: 0;
+  animation: og-shooting-star 12s ease-in 4s infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .og-shooting-star { animation: none; display: none; }
+}
+
+/* Static star field — themeable so it reads in BOTH modes: dark dots on light,
+   bright dots on dark. Tiled radial-gradients, repeated across the viewport. */
+.og-starfield {
+  background-image:
+    radial-gradient(1.5px 1.5px at 30px 40px, rgba(0,0,0,0.34), transparent),
+    radial-gradient(1px 1px at 110px 90px, rgba(0,0,0,0.24), transparent),
+    radial-gradient(1px 1px at 170px 28px, rgba(0,0,0,0.30), transparent),
+    radial-gradient(2px 2px at 70px 158px, rgba(0,0,0,0.30), transparent),
+    radial-gradient(1px 1px at 150px 192px, rgba(0,0,0,0.22), transparent),
+    radial-gradient(1px 1px at 205px 120px, rgba(0,0,0,0.26), transparent);
+  background-size: 220px 220px;
+  background-repeat: repeat;
+}
+[data-theme="dark"] .og-starfield {
+  background-image:
+    radial-gradient(1.5px 1.5px at 30px 40px, rgba(255,255,255,0.95), transparent),
+    radial-gradient(1px 1px at 110px 90px, rgba(255,255,255,0.70), transparent),
+    radial-gradient(1px 1px at 170px 28px, rgba(255,255,255,0.85), transparent),
+    radial-gradient(2px 2px at 70px 158px, rgba(255,255,255,0.90), transparent),
+    radial-gradient(1px 1px at 150px 192px, rgba(255,255,255,0.60), transparent),
+    radial-gradient(1px 1px at 205px 120px, rgba(255,255,255,0.78), transparent);
+}

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -357,12 +357,12 @@ code {
    bright dots on dark. Tiled radial-gradients, repeated across the viewport. */
 .og-starfield {
   background-image:
-    radial-gradient(1.5px 1.5px at 30px 40px, rgba(0,0,0,0.34), transparent),
-    radial-gradient(1px 1px at 110px 90px, rgba(0,0,0,0.24), transparent),
-    radial-gradient(1px 1px at 170px 28px, rgba(0,0,0,0.30), transparent),
-    radial-gradient(2px 2px at 70px 158px, rgba(0,0,0,0.30), transparent),
-    radial-gradient(1px 1px at 150px 192px, rgba(0,0,0,0.22), transparent),
-    radial-gradient(1px 1px at 205px 120px, rgba(0,0,0,0.26), transparent);
+    radial-gradient(1.5px 1.5px at 30px 40px, rgba(0,0,0,0.55), transparent),
+    radial-gradient(1px 1px at 110px 90px, rgba(0,0,0,0.42), transparent),
+    radial-gradient(1.5px 1.5px at 170px 28px, rgba(0,0,0,0.50), transparent),
+    radial-gradient(2px 2px at 70px 158px, rgba(0,0,0,0.50), transparent),
+    radial-gradient(1px 1px at 150px 192px, rgba(0,0,0,0.38), transparent),
+    radial-gradient(1px 1px at 205px 120px, rgba(0,0,0,0.45), transparent);
   background-size: 220px 220px;
   background-repeat: repeat;
 }

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { motion } from 'motion/react';
-import { LockKey, X } from '@phosphor-icons/react';
+import { LockKey, X, CheckCircle, Desktop, EnvelopeSimple } from '@phosphor-icons/react';
 import { ProgressiveBlur } from './ui/progressive-blur';
 import { SetupPanel } from './setup/SetupPanel';
 import { StoragePanel } from './setup/StoragePanel';
@@ -139,6 +139,84 @@ function SecretaryPrefs(): React.ReactElement {
   );
 }
 
+const MAX_DEVICES = 5;
+interface PlanInfo { isPro: boolean; tier: 'lifetime' | 'monthly' | null; expiry: string | null }
+interface PlanDevice { id: string; name?: string; platform?: string; lastSeen?: string }
+
+// Pro plan + devices, mirroring mobile's ProManageSection. Read-only device list
+// (the cap is fixed, no self-service removal); for monthly, the cancel/update path
+// is the link in the purchase/renewal email (no in-app billing portal).
+function ProPlanSection(): React.ReactElement {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const api = (window as any).api;
+  const [info, setInfo] = useState<PlanInfo | null>(null);
+  const [devices, setDevices] = useState<PlanDevice[]>([]);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    let live = true;
+    void Promise.all([api?.license?.status?.(), api?.license?.listDevices?.()])
+      .then(([i, d]: [PlanInfo, PlanDevice[]]) => { if (!live) return; setInfo(i ?? null); setDevices(Array.isArray(d) ? d : []); })
+      .catch(() => {})
+      .finally(() => { if (live) setLoading(false); });
+    return () => { live = false; };
+  }, [api]);
+
+  const fmt = (iso?: string | null): string => {
+    if (!iso) return '';
+    try { return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }); } catch { return iso; }
+  };
+  const statusLine = info?.tier === 'lifetime' ? 'Lifetime · never expires'
+    : info?.tier === 'monthly' ? `Monthly · active until ${fmt(info.expiry)}`
+    : 'Pro active';
+
+  return (
+    <motion.div
+      className="rounded-2xl bg-neutral-900/60 backdrop-blur-sm border border-neutral-800 p-6"
+      initial={{ opacity: 0, filter: 'blur(10px)' }}
+      animate={{ opacity: 1, filter: 'blur(0px)' }}
+      transition={{ duration: 0.6, delay: 0.3 }}
+    >
+      <h3 className="text-white font-medium text-base mb-1">Your Pro plan</h3>
+      <p className="text-neutral-500 text-sm mb-4">Your subscription and the devices on this license.</p>
+      {loading ? (
+        <p className="text-sm text-neutral-600">Loading…</p>
+      ) : (
+        <>
+          <div className="flex items-center gap-2 text-sm text-neutral-200">
+            <CheckCircle weight="fill" className="h-4 w-4 text-green-500" /> {statusLine}
+          </div>
+
+          <div className="mt-5">
+            <div className="text-[11px] uppercase tracking-wide text-neutral-500">Devices ({devices.length} of {MAX_DEVICES})</div>
+            <p className="mt-0.5 text-[11px] text-neutral-600">A license works on up to {MAX_DEVICES} devices. This limit is fixed.</p>
+            <ul className="mt-2 divide-y divide-neutral-800/60 overflow-hidden rounded-xl border border-neutral-800 bg-neutral-950/40">
+              {devices.length === 0 ? (
+                <li className="px-3 py-2 text-sm text-neutral-600">No devices registered yet.</li>
+              ) : devices.map((m) => (
+                <li key={m.id} className="flex items-center gap-2.5 px-3 py-2">
+                  <Desktop className="h-4 w-4 shrink-0 text-neutral-500" />
+                  <span className="min-w-0 flex-1 truncate text-sm text-neutral-300">{m.name || m.platform || 'Device'}</span>
+                  {m.lastSeen && <span className="shrink-0 text-[11px] text-neutral-600">Added {fmt(m.lastSeen)}</span>}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {info?.tier === 'monthly' && (
+            <div className="mt-5">
+              <div className="text-[11px] uppercase tracking-wide text-neutral-500">Manage subscription</div>
+              <p className="mt-1 flex items-start gap-2 text-[11px] text-neutral-500">
+                <EnvelopeSimple className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                To cancel or update your payment method, use the link in your Off Grid purchase or renewal email - one is sent with every payment.
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </motion.div>
+  );
+}
+
 
 export function Settings() {
   // Pro/core aware: the proactive / secretary / fleet-console sections are Pro
@@ -239,6 +317,7 @@ export function Settings() {
           {/* Pro sections — shown but disabled in the free build. */}
           {isPro ? <ProactiveSection /> : <ProPlaceholder title="Proactive delivery" description="A morning briefing and a heads-up before each meeting — native notifications, even when the window is closed." />}
           {isPro ? <SecretaryPrefs /> : <ProPlaceholder title="What Off Grid has learned" description="Preferences distilled from the suggestions you dismiss, fed back to your assistant so it gets sharper over time." />}
+          {isPro && <ProPlanSection />}
 
           {/* Data & privacy — one place to delete on-device data. */}
           <motion.div

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -1,10 +1,53 @@
 import { useEffect, useState } from 'react';
 import { motion } from 'motion/react';
-import { LockKey, X, CheckCircle, Desktop, EnvelopeSimple } from '@phosphor-icons/react';
+import { LockKey, X, CheckCircle, Desktop, EnvelopeSimple, CaretDown } from '@phosphor-icons/react';
+import { cn } from '@renderer/lib/utils';
 import { ProgressiveBlur } from './ui/progressive-blur';
 import { SetupPanel } from './setup/SetupPanel';
 import { StoragePanel } from './setup/StoragePanel';
 import { DataPrivacyPanel } from './setup/DataPrivacyPanel';
+
+// Collapsible Settings card: same chrome as before, but the body is hidden until
+// the user expands it (closed by default). The header shows the title always and a
+// one-line summary while collapsed, with a chevron that flips when open. Keeps the
+// long Settings sections scannable.
+function SettingsCard({
+  title,
+  summary,
+  defaultOpen = false,
+  children,
+  delay = 0.13,
+}: {
+  title: string;
+  summary: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+  delay?: number;
+}): React.ReactElement {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <motion.div
+      className="overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900/60 backdrop-blur-sm"
+      initial={{ opacity: 0, filter: 'blur(10px)' }}
+      animate={{ opacity: 1, filter: 'blur(0px)' }}
+      transition={{ duration: 0.6, delay }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-3 p-6 text-left"
+      >
+        <div className="min-w-0 flex-1">
+          <h3 className="text-base font-medium text-white">{title}</h3>
+          {!open && <p className="mt-1 text-sm text-neutral-500">{summary}</p>}
+        </div>
+        <CaretDown className={cn('h-4 w-4 shrink-0 text-neutral-500 transition-transform', open && 'rotate-180')} />
+      </button>
+      {open && <div className="px-6 pb-6">{children}</div>}
+    </motion.div>
+  );
+}
 
 // A Pro section shown (disabled) in the free build: title + description + a
 // "Pro · July 2026" badge, dimmed and non-interactive.
@@ -45,30 +88,21 @@ function ProactiveSection(): React.ReactElement {
     setEnabled(next);
     api.saveSetting?.('proactive:enabled', next);
   };
+  // Body only — the card chrome + title come from SettingsCard.
   return (
-    <motion.div
-      className="rounded-2xl bg-neutral-900/60 backdrop-blur-sm border border-neutral-800 p-6"
-      initial={{ opacity: 0, filter: 'blur(10px)' }}
-      animate={{ opacity: 1, filter: 'blur(0px)' }}
-      transition={{ duration: 0.6, delay: 0.18 }}
-    >
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h3 className="text-white font-medium text-base mb-1">Proactive delivery</h3>
-          <p className="text-neutral-500 text-sm">
-            Off Grid reaches out on its own — a morning briefing of your day and a heads-up ~20 min before each meeting with who’s in it and your open items. Delivered as native notifications, even when the window is closed.
-          </p>
-        </div>
-        <button
-          onClick={toggle}
-          role="switch"
-          aria-checked={enabled}
-          className={`relative mt-1 inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${enabled ? 'bg-emerald-500' : 'bg-neutral-700'}`}
-        >
-          <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${enabled ? 'translate-x-6' : 'translate-x-1'}`} />
-        </button>
-      </div>
-    </motion.div>
+    <div className="flex items-start justify-between gap-4">
+      <p className="text-neutral-500 text-sm">
+        Off Grid reaches out on its own - a morning briefing of your day and a heads-up ~20 min before each meeting with who is in it and your open items. Delivered as native notifications, even when the window is closed.
+      </p>
+      <button
+        onClick={toggle}
+        role="switch"
+        aria-checked={enabled}
+        className={`relative mt-1 inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${enabled ? 'bg-emerald-500' : 'bg-neutral-700'}`}
+      >
+        <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${enabled ? 'translate-x-6' : 'translate-x-1'}`} />
+      </button>
+    </div>
   );
 }
 
@@ -98,16 +132,11 @@ function SecretaryPrefs(): React.ReactElement {
   };
   const clear = async (): Promise<void> => { setDoc(''); await api.secretaryPrefsSet?.(''); };
 
+  // Body only — the card chrome + title come from SettingsCard.
   return (
-    <motion.div
-      className="rounded-2xl bg-neutral-900/60 backdrop-blur-sm border border-neutral-800 p-6"
-      initial={{ opacity: 0, filter: 'blur(10px)' }}
-      animate={{ opacity: 1, filter: 'blur(0px)' }}
-      transition={{ duration: 0.6, delay: 0.18 }}
-    >
-      <h3 className="text-white font-medium text-base mb-1">What Off Grid has learned</h3>
+    <div>
       <p className="text-neutral-500 text-sm mb-4">
-        Preferences distilled from the reasons you give when you dismiss a suggestion. This is the only learned text fed back to the assistant — it refreshes about once an hour, and raw notes are never used directly. You can remove any line you disagree with.
+        Preferences distilled from the reasons you give when you dismiss a suggestion. This is the only learned text fed back to the assistant - it refreshes about once an hour, and raw notes are never used directly. You can remove any line you disagree with.
       </p>
       {lines.length ? (
         <ul className="divide-y divide-neutral-800/60 overflow-hidden rounded-xl border border-neutral-700/50 bg-neutral-800/40">
@@ -127,7 +156,7 @@ function SecretaryPrefs(): React.ReactElement {
         </ul>
       ) : (
         <p className="rounded-xl border border-neutral-700/50 bg-neutral-800/40 p-3 text-sm text-neutral-600">
-          Nothing learned yet. When you dismiss a suggestion, tell Off Grid why — it generalizes the useful ones here.
+          Nothing learned yet. When you dismiss a suggestion, tell Off Grid why - it generalizes the useful ones here.
         </p>
       )}
       {lines.length > 0 && (
@@ -135,7 +164,7 @@ function SecretaryPrefs(): React.ReactElement {
           <button onClick={clear} className="rounded-lg px-3 py-1.5 text-xs text-neutral-500 hover:text-white">Clear all</button>
         </div>
       )}
-    </motion.div>
+    </div>
   );
 }
 
@@ -169,15 +198,9 @@ function ProPlanSection(): React.ReactElement {
     : info?.tier === 'monthly' ? `Monthly · active until ${fmt(info.expiry)}`
     : 'Pro active';
 
+  // Body only — the card chrome + title come from SettingsCard.
   return (
-    <motion.div
-      className="rounded-2xl bg-neutral-900/60 backdrop-blur-sm border border-neutral-800 p-6"
-      initial={{ opacity: 0, filter: 'blur(10px)' }}
-      animate={{ opacity: 1, filter: 'blur(0px)' }}
-      transition={{ duration: 0.6, delay: 0.3 }}
-    >
-      <h3 className="text-white font-medium text-base mb-1">Your Pro plan</h3>
-      <p className="text-neutral-500 text-sm mb-4">Your subscription and the devices on this license.</p>
+    <div>
       {loading ? (
         <p className="text-sm text-neutral-600">Loading…</p>
       ) : (
@@ -213,7 +236,7 @@ function ProPlanSection(): React.ReactElement {
           )}
         </>
       )}
-    </motion.div>
+    </div>
   );
 }
 
@@ -274,64 +297,54 @@ export function Settings() {
           transition={{ duration: 0.5, ease: [0.25, 0.46, 0.45, 0.94] }}
         >
 
-          {/* Setup & health — available in every build. Re-run setup or check
-              what's running at any time. */}
-          <motion.div
-            className="rounded-2xl bg-neutral-900/60 backdrop-blur-sm border border-neutral-800 p-6"
-            initial={{ opacity: 0, filter: 'blur(10px)' }}
-            animate={{ opacity: 1, filter: 'blur(0px)' }}
-            transition={{ duration: 0.6, delay: 0.13 }}
-          >
-            <h3 className="text-white font-medium text-base mb-1">Setup &amp; health</h3>
-            <p className="text-neutral-500 text-sm mb-4">
-              Set up your local AI in one click, or browse models yourself. The status of every
-              on-device component is shown live below.
-            </p>
+          {/* Each section is a collapsed-by-default accordion (SettingsCard). */}
+          <SettingsCard title="Setup & health" summary="Set up your local AI, manage storage, and see live component health." delay={0.13}>
             <SetupPanel />
             <div className="mt-4">
               <StoragePanel />
             </div>
-          </motion.div>
+          </SettingsCard>
 
           {/* Identity — who you are (Pro: foundation for the act pillar) */}
           {isPro ? (
-            <motion.div
-              className="rounded-2xl bg-neutral-900/60 backdrop-blur-sm border border-neutral-800 p-6"
-              initial={{ opacity: 0, filter: 'blur(10px)' }}
-              animate={{ opacity: 1, filter: 'blur(0px)' }}
-              transition={{ duration: 0.6, delay: 0.15 }}
-            >
-              <h3 className="text-white font-medium text-base mb-1">You</h3>
+            <SettingsCard title="You" summary="Who you are, so Off Grid can attribute your messages and calendar." delay={0.15}>
               <p className="text-neutral-500 text-sm mb-4">
-                Tells Off Grid who “you” are — so it can tell your messages and commitments apart from everyone else’s. Used to attribute action items and to make sense of your email and calendar.
+                Tells Off Grid who you are - so it can tell your messages and commitments apart from everyone else&apos;s. Used to attribute action items and to make sense of your email and calendar.
               </p>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <input value={idName} onChange={(e) => setIdName(e.target.value)} onBlur={saveIdentity} placeholder="Your name" className="rounded-xl bg-neutral-950 border border-neutral-800 px-3 py-2 text-sm text-neutral-200 outline-none focus:border-neutral-600" />
                 <input value={idEmail} onChange={(e) => setIdEmail(e.target.value)} onBlur={saveIdentity} placeholder="you@email.com" className="rounded-xl bg-neutral-950 border border-neutral-800 px-3 py-2 text-sm text-neutral-200 outline-none focus:border-neutral-600" />
               </div>
-            </motion.div>
+            </SettingsCard>
           ) : (
-            <ProPlaceholder delay={0.15} title="You" description="Tell Off Grid who you are so it can attribute your messages, commitments, and calendar — part of the Pro intelligence layer." />
+            <ProPlaceholder delay={0.15} title="You" description="Tell Off Grid who you are so it can attribute your messages, commitments, and calendar - part of the Pro intelligence layer." />
           )}
 
           {/* Pro sections — shown but disabled in the free build. */}
-          {isPro ? <ProactiveSection /> : <ProPlaceholder title="Proactive delivery" description="A morning briefing and a heads-up before each meeting — native notifications, even when the window is closed." />}
-          {isPro ? <SecretaryPrefs /> : <ProPlaceholder title="What Off Grid has learned" description="Preferences distilled from the suggestions you dismiss, fed back to your assistant so it gets sharper over time." />}
-          {isPro && <ProPlanSection />}
+          {isPro ? (
+            <SettingsCard title="Proactive delivery" summary="A morning briefing and a heads-up before each meeting." delay={0.18}>
+              <ProactiveSection />
+            </SettingsCard>
+          ) : (
+            <ProPlaceholder title="Proactive delivery" description="A morning briefing and a heads-up before each meeting - native notifications, even when the window is closed." />
+          )}
+          {isPro ? (
+            <SettingsCard title="What Off Grid has learned" summary="Preferences distilled from your dismissals, fed back to the assistant." delay={0.22}>
+              <SecretaryPrefs />
+            </SettingsCard>
+          ) : (
+            <ProPlaceholder title="What Off Grid has learned" description="Preferences distilled from the suggestions you dismiss, fed back to your assistant so it gets sharper over time." />
+          )}
+          {isPro && (
+            <SettingsCard title="Your Pro plan" summary="Your subscription, devices, and how to cancel." delay={0.3}>
+              <ProPlanSection />
+            </SettingsCard>
+          )}
 
           {/* Data & privacy — one place to delete on-device data. */}
-          <motion.div
-            className="rounded-2xl bg-neutral-900/60 backdrop-blur-sm border border-neutral-800 p-6"
-            initial={{ opacity: 0, filter: 'blur(10px)' }}
-            animate={{ opacity: 1, filter: 'blur(0px)' }}
-            transition={{ duration: 0.6, delay: 0.42 }}
-          >
-            <h3 className="text-white font-medium text-base mb-1">Data &amp; privacy</h3>
-            <p className="text-neutral-500 text-sm mb-4">
-              Everything stays on this device. Delete any of it from here — per category, or all at once.
-            </p>
+          <SettingsCard title="Data & privacy" summary="See and delete on-device data, per category or all at once." delay={0.42}>
             <DataPrivacyPanel />
-          </motion.div>
+          </SettingsCard>
 
           {/* Version footer — so you always know which build you're on. */}
           <div className="flex items-center justify-center gap-2 pt-2 text-xs text-neutral-600">

--- a/src/renderer/src/components/ui/starfield-backdrop.tsx
+++ b/src/renderer/src/components/ui/starfield-backdrop.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@renderer/lib/utils';
+
+/** Starry-night layer over the terminal grid, in BOTH themes (themeable dots:
+ *  dark on light, bright on dark — see .og-starfield in main.css), plus a periodic
+ *  emerald shooting star (.og-shooting-star). Pure CSS, no deps, pointer-events-none
+ *  so it never intercepts clicks. Respects prefers-reduced-motion. */
+export function StarfieldBackdrop({ className }: { className?: string }): React.ReactElement {
+  return (
+    <div
+      aria-hidden
+      className={cn('pointer-events-none absolute inset-0 overflow-hidden', className)}
+    >
+      <div className="og-starfield absolute inset-0" />
+      <span className="og-shooting-star" />
+    </div>
+  );
+}


### PR DESCRIPTION
Promotes accumulated `release-core` work to `main` for the `0.0.26` build.

## Highlights
- **Auto-update: no Pro user orphaned** — old Pro builds poll a separate `pro-mac.yml` channel; the single build now publishes only `latest-mac.yml`. `release.yml` now also uploads `pro-mac.yml` (copy of `latest-mac.yml`, same signed zip) so legacy Pro installs see this release, update, and migrate onto the default channel.
- **DevTools disabled in packaged builds** (`devTools: is.dev`) — no inspector in production (matches the ASAR-integrity tamper-proofing).
- **Settings accordions** — every section collapses to a title + summary, expandable on click (long cards were unwieldy).
- **Pro plan section** in Settings — active plan (lifetime/monthly + expiry), devices (N of 5), cancel/update-via-email note (mirrors mobile).
- **Starry-night backdrop** — themeable star dots + an emerald shooting star over the terminal grid, visible in both themes.

## Verification (local)
- `tsc --noEmit` clean (node + web)
- `npm test` — unit suites green
- `npm run test:e2e` — **9/9** Playwright Electron tour pass (boots without white screen, onboarding, Models, Settings accordions expand + assert, Clipboard-as-Pro, Gateway)

## Notes
- Merging triggers `release.yml` → bumps to `0.0.26`, signs + notarizes, publishes `latest-mac.yml` **and** `pro-mac.yml`.
- `release-core` synced with `main` (0.0.25 bump merged) so this diff is just the new work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a starfield background with periodic shooting-star animation.
  * Updated the Settings page to use reusable collapsible accordions with clearer section summaries.
* **Bug Fixes**
  * Restored legacy mac update channel metadata in releases for Pro installs.
  * Improved Settings accordion behavior so tests/assertions handle collapsed sections consistently.
* **Chores**
  * Made DevTools availability development-only for a cleaner production experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->