### PR TITLE
fix(update): drive install with quitAndInstall + "Restart to update" banner

### DIFF
--- a/src/main/__tests__/updater.test.ts
+++ b/src/main/__tests__/updater.test.ts
@@ -33,6 +33,14 @@ describe('auto-update: explicit install path', () => {
     expect(updaterSrc).toMatch(/send\(\s*['"]update:downloaded['"]/);
   });
 
+  it('persists the staged version + exposes a getter (macOS zero-window case)', () => {
+    // The event only reaches windows open at download time; a window created
+    // later must still be able to ask whether an update is already staged.
+    expect(updaterSrc).toMatch(/stagedVersion\s*=\s*i\.version/);
+    expect(updaterSrc).toMatch(/ipcMain\.handle\(\s*['"]update:staged-version['"]/);
+    expect(preloadSrc).toMatch(/getStagedUpdateVersion:\s*\(\)\s*=>\s*ipcRenderer\.invoke\(\s*['"]update:staged-version['"]/);
+  });
+
   it('preload bridges installUpdate() to the update:install channel', () => {
     expect(preloadSrc).toMatch(/installUpdate:\s*\(\)\s*=>\s*ipcRenderer\.invoke\(\s*['"]update:install['"]/);
   });

--- a/src/main/__tests__/updater.test.ts
+++ b/src/main/__tests__/updater.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression guard for the "downloaded update never installs" bug. Squirrel.Mac
+ * only swaps the app bundle on a GRACEFUL quit (autoInstallOnAppQuit); a
+ * force-kill (Activity Monitor, kill -9, the dev-restart path) skips it, so a
+ * fully-downloaded update can sit staged forever (observed: a complete 0.0.25
+ * download that never applied while the app stayed on 0.0.24).
+ *
+ * The fix exposes an explicit install path: main registers an `update:install`
+ * IPC that calls autoUpdater.quitAndInstall(), and the renderer surfaces a
+ * "Restart to update" button driven by it. updater.ts imports electron, so it
+ * can't be unit-run — assert the contract by reading the source (same approach
+ * as extract-prompt.test.ts).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const UPDATER = path.resolve(process.cwd(), 'src/main/updater.ts');
+const PRELOAD = path.resolve(process.cwd(), 'src/preload/index.ts');
+const updaterSrc = fs.readFileSync(UPDATER, 'utf-8');
+const preloadSrc = fs.readFileSync(PRELOAD, 'utf-8');
+
+describe('auto-update: explicit install path', () => {
+  it('registers an update:install IPC handler', () => {
+    expect(updaterSrc).toMatch(/ipcMain\.handle\(\s*['"]update:install['"]/);
+  });
+
+  it('drives the install via quitAndInstall (not a passive wait for quit)', () => {
+    expect(updaterSrc).toMatch(/autoUpdater\.quitAndInstall\(\)/);
+  });
+
+  it('still emits update:downloaded so the renderer can prompt', () => {
+    expect(updaterSrc).toMatch(/send\(\s*['"]update:downloaded['"]/);
+  });
+
+  it('preload bridges installUpdate() to the update:install channel', () => {
+    expect(preloadSrc).toMatch(/installUpdate:\s*\(\)\s*=>\s*ipcRenderer\.invoke\(\s*['"]update:install['"]/);
+  });
+
+  it('preload subscribes the renderer to update:downloaded', () => {
+    expect(preloadSrc).toMatch(/onUpdateDownloaded/);
+    expect(preloadSrc).toMatch(/ipcRenderer\.on\(\s*['"]update:downloaded['"]/);
+  });
+});

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -4,6 +4,13 @@
 import { autoUpdater } from 'electron-updater';
 import { BrowserWindow, ipcMain } from 'electron';
 
+// Version of an update that finished downloading and is staged for install
+// (null = none). Held in main so a window created AFTER the download finished
+// (on macOS the app keeps running with zero windows) can still seed the banner
+// via update:staged-version — the update:downloaded event alone only reaches
+// windows that existed at download time.
+let stagedVersion: string | null = null;
+
 export function startAutoUpdates(): void {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
@@ -17,12 +24,16 @@ export function startAutoUpdates(): void {
     autoUpdater.quitAndInstall();
   });
 
+  // Lets a freshly-created window ask whether an update is already staged.
+  ipcMain.handle('update:staged-version', () => stagedVersion);
+
   autoUpdater.on('error', (e) => console.error('[update] error', e));
   autoUpdater.on('checking-for-update', () => console.log('[update] checking…'));
   autoUpdater.on('update-available', (i) => console.log('[update] available', i.version));
   autoUpdater.on('update-not-available', () => console.log('[update] up to date'));
   autoUpdater.on('update-downloaded', (i) => {
     console.log('[update] downloaded', i.version, '— will install on quit');
+    stagedVersion = i.version;
     BrowserWindow.getAllWindows().forEach((w) => w.webContents.send('update:downloaded', { version: i.version }));
   });
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -2,11 +2,20 @@
 // few hours; downloads in the background and installs on quit. A native
 // notification fires when an update is downloaded (checkForUpdatesAndNotify).
 import { autoUpdater } from 'electron-updater';
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, ipcMain } from 'electron';
 
 export function startAutoUpdates(): void {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
+
+  // Apply a staged update on demand. autoInstallOnAppQuit only swaps the bundle
+  // on a GRACEFUL quit — a force-kill (Activity Monitor, kill -9, killall) skips
+  // it, so a fully-downloaded update can sit unapplied forever. quitAndInstall
+  // forces the clean quit + relaunch + swap, so the renderer's "Restart to
+  // update" button always lands the update regardless of how the app is closed.
+  ipcMain.handle('update:install', () => {
+    autoUpdater.quitAndInstall();
+  });
 
   autoUpdater.on('error', (e) => console.error('[update] error', e));
   autoUpdater.on('checking-for-update', () => console.log('[update] checking…'));

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -126,10 +126,11 @@ try {
     // installUpdate() forces the quit+swap (Squirrel only applies on a graceful
     // quit; a force-kill would otherwise leave the download unapplied).
     onUpdateDownloaded: (callback: (data: { version: string }) => void) => {
-      const subscription = (_: any, data: any) => callback(data)
+      const subscription = (_event: unknown, data: { version: string }) => callback(data)
       ipcRenderer.on('update:downloaded', subscription)
       return () => ipcRenderer.removeListener('update:downloaded', subscription)
     },
+    getStagedUpdateVersion: () => ipcRenderer.invoke('update:staged-version'),
     installUpdate: () => ipcRenderer.invoke('update:install'),
 
     // Watcher Events

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -122,6 +122,16 @@ try {
       return () => ipcRenderer.removeListener('reprocess:progress', subscription)
     },
     
+    // Auto-update — fired when a new version finished downloading and is staged.
+    // installUpdate() forces the quit+swap (Squirrel only applies on a graceful
+    // quit; a force-kill would otherwise leave the download unapplied).
+    onUpdateDownloaded: (callback: (data: { version: string }) => void) => {
+      const subscription = (_: any, data: any) => callback(data)
+      ipcRenderer.on('update:downloaded', subscription)
+      return () => ipcRenderer.removeListener('update:downloaded', subscription)
+    },
+    installUpdate: () => ipcRenderer.invoke('update:install'),
+
     // Watcher Events
     onWatcherData: (callback: (data: any) => void) => {
       const subscription = (_: any, data: any) => callback(data)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -379,7 +379,11 @@ function AppContent() {
     }
 
     // A new version finished downloading and is staged — show the restart banner.
+    // Seed from main too: on macOS the app can keep running with no windows, so a
+    // download that finished before this window existed would otherwise be missed
+    // (the event only reaches windows open at download time).
     if (window.api?.onUpdateDownloaded) {
+      window.api.getStagedUpdateVersion?.().then((v) => { if (v) setUpdateReady(v); }).catch(() => {});
       const unsubscribe = window.api.onUpdateDownloaded((data) => {
         setUpdateReady(data.version);
       });
@@ -582,9 +586,20 @@ function AppContent() {
       {updateReady && (
         <div className="absolute right-4 top-4 z-50 flex items-center gap-3 rounded-md border border-green-500/40 bg-neutral-900/95 px-3.5 py-2 font-mono text-xs text-neutral-200 shadow-xl backdrop-blur">
           <IconDownload className="h-4 w-4 text-green-500" />
-          <span>Off Grid AI {updateReady} is ready</span>
+          <span>Update {updateReady} is ready</span>
           <button
-            onClick={() => { setInstalling(true); window.api?.installUpdate?.(); }}
+            onClick={async () => {
+              if (!window.api?.installUpdate) return;
+              setInstalling(true);
+              try {
+                await window.api.installUpdate();
+              } catch {
+                // quitAndInstall normally never returns (the app exits). If it
+                // rejects, unlock the button so the user can retry.
+                setInstalling(false);
+                addNotification({ type: 'info', title: 'Update restart failed', message: 'Try again from the update banner.' });
+              }
+            }}
             disabled={installing}
             className="flex items-center gap-1.5 rounded-sm border border-green-500/50 bg-green-500/10 px-2.5 py-1 text-green-400 hover:bg-green-500/20 disabled:opacity-60"
           >

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -161,6 +161,11 @@ function AppContent() {
   const [viewMode, setViewMode] = useState<ViewMode>(isPro ? 'day' : 'models');
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [selectedMemoryId, setSelectedMemoryId] = useState<number | null>(null);
+  // Version of a downloaded-and-staged update (null = none). Surfaced as a banner
+  // with a "Restart to update" button — Squirrel only applies on a clean quit, so
+  // we drive the install explicitly instead of waiting for one.
+  const [updateReady, setUpdateReady] = useState<string | null>(null);
+  const [installing, setInstalling] = useState(false);
   const [selectedEntityId, setSelectedEntityId] = useState<number | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   // Search filter + sort live here (not in the screen) so they survive navigating
@@ -373,6 +378,14 @@ function AppContent() {
       unsubscribers.push(unsubscribe);
     }
 
+    // A new version finished downloading and is staged — show the restart banner.
+    if (window.api?.onUpdateDownloaded) {
+      const unsubscribe = window.api.onUpdateDownloaded((data) => {
+        setUpdateReady(data.version);
+      });
+      unsubscribers.push(unsubscribe);
+    }
+
     return () => {
       unsubscribers.forEach(unsub => unsub());
     };
@@ -562,6 +575,22 @@ function AppContent() {
             </>
           )}
         </button>
+      )}
+      {/* Update ready — a new version downloaded and is staged. The button drives
+          the install (quit + swap + relaunch); a plain quit/force-kill would leave
+          it unapplied. */}
+      {updateReady && (
+        <div className="absolute right-4 top-4 z-50 flex items-center gap-3 rounded-md border border-green-500/40 bg-neutral-900/95 px-3.5 py-2 font-mono text-xs text-neutral-200 shadow-xl backdrop-blur">
+          <IconDownload className="h-4 w-4 text-green-500" />
+          <span>Off Grid AI {updateReady} is ready</span>
+          <button
+            onClick={() => { setInstalling(true); window.api?.installUpdate?.(); }}
+            disabled={installing}
+            className="flex items-center gap-1.5 rounded-sm border border-green-500/50 bg-green-500/10 px-2.5 py-1 text-green-400 hover:bg-green-500/20 disabled:opacity-60"
+          >
+            {installing ? <><IconLoader2 className="h-3.5 w-3.5 animate-spin" /> Restarting…</> : 'Restart to update'}
+          </button>
+        </div>
       )}
       {/* Background — flat Off Grid terminal grid (theme-aware), with a dark-mode
           starfield + periodic shooting star layered on top. */}

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -207,6 +207,7 @@ interface IElectronAPI {
   onNewAction: (callback: (data: { actionId: number; text: string; due: string | null; entityName: string | null; sourceApp: string }) => void) => () => void
   onReprocessProgress: (callback: (data: ReprocessProgress) => void) => () => void
   onUpdateDownloaded: (callback: (data: { version: string }) => void) => () => void
+  getStagedUpdateVersion: () => Promise<string | null>
   installUpdate: () => Promise<void>
 
   // Permission APIs

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -206,6 +206,8 @@ interface IElectronAPI {
   onNewApproval: (callback: (data: { approvalId: number; title: string; detail: string; entityName: string | null }) => void) => () => void
   onNewAction: (callback: (data: { actionId: number; text: string; due: string | null; entityName: string | null; sourceApp: string }) => void) => () => void
   onReprocessProgress: (callback: (data: ReprocessProgress) => void) => () => void
+  onUpdateDownloaded: (callback: (data: { version: string }) => void) => () => void
+  installUpdate: () => Promise<void>
 
   // Permission APIs
   getPermissionStatus: () => Promise<PermissionStatus>


### PR DESCRIPTION
## Why

A user reported the app wasn't updating off `0.0.24`. Investigation of the updater cache showed the **check + download work fine** - `0.0.26` was downloading and finalized correctly. The break is the **install step**:

- `autoInstallOnAppQuit = true` only applies the staged update on a **graceful quit**.
- Force-killing the app (Activity Monitor, `kill -9`, `killall`, dev-restart) **skips** the Squirrel swap.
- Evidence: a fully-completed `0.0.25` download from 26 Jun sat in the cache, never applied, while the app stayed on `0.0.24`.

There was no renderer listener for `update:downloaded` and **no `quitAndInstall` path at all**, so the only way to land an update was for the user to happen to Cmd+Q.

## What

- **main** (`updater.ts`): register `update:install` IPC → `autoUpdater.quitAndInstall()` (forces clean quit + swap + relaunch).
- **preload**: expose `onUpdateDownloaded()` + `installUpdate()`.
- **renderer** (`App.tsx`): "Off Grid AI `<version>` is ready / **Restart to update**" banner that drives the install directly - users no longer need to know about Cmd+Q.
- **test**: source-contract regression guard (`updater.test.ts`) - `updater.ts` imports electron so it can't be unit-run; assert the IPC + preload wiring like `extract-prompt.test.ts` does.

## Verification

- `npx tsc --noEmit` (node + web) clean
- `npm test` → 75/75 (70 existing + 5 new)
- Confirmed `0.0.26` is now fully staged in the local updater cache (`pending/Off-Grid-AI-0.0.26-arm64-mac.zip`, finalized)

Note: existing `0.0.24`/`0.0.25` installs don't have this banner, so they still need one graceful Cmd+Q to reach the version that carries it - from there forward the button handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-app update banner after a download completes, with a **Restart to update** action.
  * Automatically restores the “update ready” state for windows opened after the download finishes.
* **Bug Fixes**
  * Update installation now triggers an explicit install restart on demand (instead of relying on a later app quit), with staged-version support.
  * Restart button is disabled while installing; failures show an info notification.
* **Tests**
  * Added regression coverage for the update download→install IPC contract and staged-update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->