### PR TITLE
docs(readme): add Clipboard to Pro features

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ explicit opt-in, with a visible recording indicator, and nothing leaves the devi
 - **Reflects** — mind-share, balance, context-switching, and Day/Week trends.
 - **Meetings** — records **Google Meet + Zoom** (screen + system audio + mic), transcribes
   locally with whisper, and folds an LLM title/summary/attendees into your timeline.
+- **Clipboard** — a private clipboard manager: searchable history of everything you copy,
+  with image, PDF, and file previews, a quick-paste popup, all stored on-device.
 - **Acts (with approval)** — action items detected from your communication, an
   approval queue + audit log (nothing executes without a logged approval), MCP connectors
   as authoritative sources, and a skills framework (trigger → action) — on the roadmap


### PR DESCRIPTION
Adds the shipped **Clipboard** manager (copyclip → Pro tier: searchable on-device history, image/PDF/file previews, quick-paste popup) to the Pro feature list. Docs-only.

Surveyed recent commits — the rest is minor/cosmetic (health dot, Settings accordions, starfield, auto-update banner); the Day bento is still on a feature branch (not merged), so not documented as shipped yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Clipboard feature highlight, describing private searchable clipboard history with image, PDF, and file previews.
  * Noted quick-paste popup access and on-device storage for easier reuse of copied items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->