### PR TITLE
fix(health): show "Loading model…" during warm-up instead of a false "Down"

### DIFF
--- a/src/main/__tests__/chat-health.test.ts
+++ b/src/main/__tests__/chat-health.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Guards the chat (llama-server) health decision. The motivating bug: while a
+ * model loads (several seconds at -ngl 99), /health returns 503 and the server
+ * isn't "ready" yet — the old logic showed a scary "down: server is not running"
+ * during every cold start, so a user opened Settings mid-load and thought 0.0.29
+ * was broken when the server was simply warming up. The load window MUST read as
+ * 'starting', not 'down'.
+ */
+import { describe, it, expect } from 'vitest';
+import { decideChatStatus } from '../chat-health';
+
+describe('decideChatStatus', () => {
+  it('ready when /health answers, detail = active model', () => {
+    const r = decideChatStatus({ healthy: true, loading: false, modelsExist: true, activeModel: 'gemma-4-E4B' });
+    expect(r.status).toBe('ready');
+    expect(r.detail).toBe('gemma-4-E4B');
+  });
+
+  it('the bug: alive-but-loading reads as starting, NOT down', () => {
+    const r = decideChatStatus({ healthy: false, loading: true, modelsExist: true });
+    expect(r.status).toBe('starting');
+    expect(r.detail).toMatch(/loading/i);
+  });
+
+  it('loading takes precedence over the down fallback even if a stale error exists', () => {
+    const r = decideChatStatus({ healthy: false, loading: true, modelsExist: true, lastError: 'old failure' });
+    expect(r.status).toBe('starting');
+  });
+
+  it('not_installed when no model on disk', () => {
+    expect(decideChatStatus({ healthy: false, loading: false, modelsExist: false }).status).toBe('not_installed');
+  });
+
+  it('down (with the real reason) when the process is not running and we have one', () => {
+    const r = decideChatStatus({ healthy: false, loading: false, modelsExist: true, lastError: 'A required engine library is missing or could not be loaded.' });
+    expect(r.status).toBe('down');
+    expect(r.detail).toMatch(/engine library/i);
+  });
+
+  it('down with a generic message when there is no captured reason', () => {
+    const r = decideChatStatus({ healthy: false, loading: false, modelsExist: true });
+    expect(r.status).toBe('down');
+    expect(r.detail).toMatch(/not running/i);
+  });
+});

--- a/src/main/chat-health.ts
+++ b/src/main/chat-health.ts
@@ -1,0 +1,34 @@
+// Decide the chat (llama-server) health status shown in System Health. Kept pure
+// + Electron-free so it's unit-testable (see __tests__/chat-health.test.ts).
+//
+// The motivating bug: while a model loads (several seconds at -ngl 99),
+// llama-server's /health returns HTTP 503 ("loading model"), so the HTTP probe
+// reports not-healthy AND the server isn't "ready" yet — and the old logic fell
+// straight to "down: server is not running". Users opened Settings mid-load and
+// saw a scary red "Down" on a server that was simply warming up. This distinguishes
+// "alive but loading" (starting) from "genuinely not running" (down).
+
+export type ChatHealthStatus = 'ready' | 'starting' | 'down' | 'not_installed';
+
+export interface ChatHealthInputs {
+  /** /health answered 200 (model loaded, accepting requests). */
+  healthy: boolean;
+  /** The server process is alive but hasn't finished loading the model yet, OR
+   *  /health answered 503 "loading". This is the normal warm-up window. */
+  loading: boolean;
+  /** A chat model exists on disk. */
+  modelsExist: boolean;
+  /** Name of the active model (shown as detail when ready). */
+  activeModel?: string | null;
+  /** Human reason the server died on load, if any (from classifyLlamaError). */
+  lastError?: string | null;
+}
+
+export function decideChatStatus(i: ChatHealthInputs): { status: ChatHealthStatus; detail?: string } {
+  if (i.healthy) return { status: 'ready', detail: i.activeModel ?? undefined };
+  if (!i.modelsExist) return { status: 'not_installed', detail: 'No model installed' };
+  // Alive-but-loading must be checked BEFORE "down" — otherwise the warm-up
+  // window reads as a failure.
+  if (i.loading) return { status: 'starting', detail: 'Loading model…' };
+  return { status: 'down', detail: i.lastError ?? 'Model installed but server is not running' };
+}

--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -762,6 +762,14 @@ export class LLMService {
       return this.initialized;
   }
 
+  /** True when the server process is alive but the model hasn't finished loading
+   *  yet — the normal several-second warm-up (gemma-4 at -ngl 99 isn't instant).
+   *  Lets Health show "Loading model…" instead of a scary "server is not running"
+   *  during a cold start. */
+  isStarting() {
+      return this.server !== null && !this.initialized;
+  }
+
   /** Human, actionable reason the chat server failed to start (null when healthy
    *  or never failed). Surfaced in the Health panel so "Down" explains itself. */
   lastError(): string | null {

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -9,6 +9,7 @@
 import os from 'os';
 import * as http from 'http';
 import { llm } from './llm';
+import { decideChatStatus } from './chat-health';
 import { getActiveModel, downloadModel, listInstalled, setActiveModel, setActiveModalChoice } from './models-manager';
 
 export type ComponentStatus = 'ready' | 'starting' | 'down' | 'not_installed';
@@ -88,15 +89,17 @@ export async function getSystemHealth(): Promise<SystemHealth> {
     return v === 'ready' ? 'ready' : v === 'not_installed' ? 'not_installed' : 'down';
   };
 
-  // Chat LLM (llama-server). ready = /health answers. starting = a model is
-  // present and we've kicked off init but it isn't answering yet. not_installed =
-  // no model on disk. down = model present but server isn't coming up.
-  let chat: ComponentStatus;
-  let chatDetail: string | undefined;
-  if (llamaHealth) { chat = 'ready'; chatDetail = activeModel ?? undefined; }
-  else if (!modelsExist) { chat = 'not_installed'; chatDetail = 'No model installed'; }
-  else if (llm.isReady()) { chat = 'starting'; chatDetail = 'Warming up…'; }
-  else { chat = 'down'; chatDetail = llm.lastError() ?? 'Model installed but server is not running'; }
+  // Chat LLM (llama-server). ready = /health answers 200. starting = the process
+  // is alive but the model is still loading (cold-start warm-up — /health 503).
+  // not_installed = no model on disk. down = model present but the process isn't
+  // running. (Decision extracted to chat-health.ts so it's unit-tested.)
+  const { status: chat, detail: chatDetail } = decideChatStatus({
+    healthy: !!llamaHealth,
+    loading: llm.isStarting(),
+    modelsExist,
+    activeModel,
+    lastError: llm.lastError(),
+  });
 
   const components: HealthComponent[] = [
     { id: 'chat', label: 'Chat model (llama-server)', status: chat, detail: chatDetail, port: LLAMA_PORT, canRestart: modelsExist },


### PR DESCRIPTION
During a cold start the model takes several seconds to load (gemma-4 at `-ngl 99`). In that window llama-server `/health` returns **503** and `llm.isReady()` is still false, so System Health showed **"Down — Model installed but server is not running."** A user opened Settings mid-load and reasonably concluded 0.0.29 was broken — when the server was just warming up and came up fine seconds later.

## Fix
- `llm.isStarting()` — process alive but not yet initialized = warm-up.
- Extract the decision to pure `chat-health.ts` (`decideChatStatus`) + unit tests. Alive-but-loading → `starting` ("Loading model…"); `down` is reserved for a process that genuinely is not running (still surfaces the classified reason when we have one).

## Verified
`npx tsc --noEmit -p tsconfig.node.json` clean; 6/6 `chat-health.test.ts` pass, including the regression that the load window reads as `starting` not `down`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat health now shows a clearer status for the server, including **Ready**, **Starting**, **Down**, and **Not Installed**.
  * When the server is still loading, the UI can now report a **starting** state instead of showing it as unavailable.
  * Status details are more descriptive, including model-related and server-not-running messages.
* **Bug Fixes**
  * Fixed the cold-start case where an active server could incorrectly appear **down** while still initializing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->