### PR TITLE
fix(core): blank white screen on boot (0.0.34) — orphaned proItem('voice')

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -489,8 +489,16 @@ function AppContent() {
   // static catalogue and are marked locked in the free build (open the
   // UpgradeScreen); core tabs (Projects / Chat / Models / Settings) sit where
   // they always did.
-  const proItem = (route: string): { label: string; icon: React.ReactNode; view: ViewMode; locked: boolean } => {
-    const f = getProFeature(route)!;
+  // A missing catalog entry must NEVER blank the whole app — no error boundary
+  // wraps the nav, so a TypeError here white-screens every user on boot (0.0.34).
+  // If a route has no ProFeature, skip that item and warn; a dropped tab is
+  // recoverable, a render-time throw is not.
+  const proItem = (route: string): { label: string; icon: React.ReactNode; view: ViewMode; locked: boolean } | null => {
+    const f = getProFeature(route);
+    if (!f) {
+      console.warn(`[nav] no pro catalog entry for "${route}" — skipping nav item`);
+      return null;
+    }
     return {
       label: f.label,
       icon: <f.icon className="h-5 w-5 shrink-0 text-neutral-400" weight="regular" />,
@@ -509,13 +517,12 @@ function AppContent() {
     proItem('entities'),
     { label: 'Projects', icon: <IconFolders className="h-5 w-5 shrink-0" />, view: 'projects' as ViewMode },
     { label: 'Chat', icon: <IconMessageCircle className="h-5 w-5 shrink-0" />, view: 'memory-chat' as ViewMode },
-    proItem('voice'),
     proItem('clipboard'),
     { label: 'Integrations', icon: <IconPlug className="h-5 w-5 shrink-0" />, view: 'connectors' as ViewMode },
     { label: 'Models', icon: <IconDownload className="h-5 w-5 shrink-0" />, view: 'models' as ViewMode },
     { label: 'Gateway', icon: <IconServer2 className="h-5 w-5 shrink-0" />, view: 'gateway' as ViewMode },
     proItem('notifications'),
-  ];
+  ].filter((i): i is { label: string; icon: React.ReactNode; view: ViewMode; locked: boolean } => i !== null);
   const bottomNav: { label: string; icon: React.ReactNode; view: ViewMode; locked?: boolean }[] = [
     { label: 'Settings', icon: <IconSettings className="h-5 w-5 shrink-0" />, view: 'settings' as ViewMode },
   ];

--- a/src/renderer/src/components/pro/__tests__/proCatalog.nav.test.ts
+++ b/src/renderer/src/components/pro/__tests__/proCatalog.nav.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression guard for the 0.0.34 WHITE-SCREEN bug: App.tsx shipped a
+ * `proItem('voice')` nav entry, but no `voice` entry existed in PRO_FEATURES.
+ * proItem did `getProFeature(route)!` (the `!` is compile-time only), so
+ * getProFeature returned undefined and `f.label` threw a TypeError during
+ * render. No error boundary wraps the nav, so the whole app went blank for
+ * every user on boot.
+ *
+ * This test fails if any `proItem('<route>')` referenced in App.tsx is missing
+ * a matching ProFeature in the catalog — the exact contract that broke.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { getProFeature } from '../proCatalog';
+
+const APP = path.resolve(process.cwd(), 'src/renderer/src/App.tsx');
+const SRC = fs.readFileSync(APP, 'utf-8');
+
+// Every route the nav builds from the catalog: proItem('search'), proItem('day'), …
+const routes = [...SRC.matchAll(/proItem\(\s*['"]([^'"]+)['"]\s*\)/g)].map((m) => m[1]);
+
+describe('App nav ↔ pro catalog contract', () => {
+  it('references at least one pro nav item (sanity)', () => {
+    expect(routes.length).toBeGreaterThan(0);
+  });
+
+  it('every proItem() route has a matching PRO_FEATURES entry', () => {
+    const missing = routes.filter((r) => !getProFeature(r));
+    expect(missing, `proItem() routes with no catalog entry: ${missing.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What broke (0.0.34)

The app boots to a **blank white window for every user** — no logs.

`App.tsx` shipped a `proItem('voice')` sidebar entry, but there is **no matching `voice` entry in `PRO_FEATURES`**. `proItem` did `getProFeature(route)!` — the `!` is compile-time only, so at runtime `getProFeature('voice')` returned `undefined` and `f.label` threw a `TypeError` while building the nav, during `AppContent` render. No error boundary wraps the nav → the whole window mounts nothing. No logs because it's a synchronous render throw in a packaged build.

The `voice` nav entry was committed ahead of its catalog entry and the feature itself (split commit). The voice/dictation work is parked on `feat/voice-dictation`.

## Fix

- **Remove the orphaned `proItem('voice')`** — voice is held off main until it ships.
- **Harden `proItem`**: a route with no catalog entry is skipped + warned, never thrown. A missing tab can no longer white-screen the app.
- **Regression guard** (`proCatalog.nav.test.ts`): reads `App.tsx`, extracts every `proItem('...')` route, asserts each resolves in `PRO_FEATURES`. Fails on this exact bug.

## Verification

- `npx tsc --noEmit` clean for both `tsconfig.web.json` and `tsconfig.node.json`
- `npm test` — 195/195 pass (incl. the new guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar stability when Pro navigation metadata is missing, preventing rendering issues or crashes.
  * Navigation now safely skips unavailable Pro items instead of showing broken entries.
* **Tests**
  * Added a regression test to ensure every Pro navigation route has matching feature metadata, helping prevent future navigation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->