### PR TITLE
fix(build): bundle @scure/bip39 into main (avoid ERR_REQUIRE_ESM)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import { existsSync } from 'fs'
-import { defineConfig } from 'electron-vite'
+import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
@@ -24,6 +24,13 @@ const proDefine = { __OFFGRID_PRO__: JSON.stringify(proExists) }
 export default defineConfig({
   main: {
     define: proDefine,
+    // Deps are externalized by default (resolved from node_modules at runtime).
+    // @scure/bip39 + @noble/hashes are ESM-only ("type":"module"); a CJS main
+    // process require()-ing them throws ERR_REQUIRE_ESM at runtime. Exclude them
+    // from externalization so Rollup BUNDLES them into the main chunk (transpiled
+    // to the output format), sidestepping the ESM/CJS boundary. Used by the pro
+    // vault recovery-phrase feature (pro/main/vault/vault-recovery.ts).
+    plugins: [externalizeDepsPlugin({ exclude: ['@scure/bip39', '@noble/hashes'] })],
     resolve: {
       alias: {
         '@offgrid/core': resolve('src'),


### PR DESCRIPTION
## Problem

`@scure/bip39` (+ its `@noble/hashes` dep) are **ESM-only** (`"type":"module"`). electron-vite externalizes dependencies for the main process by default, so the packaged CJS main would `require()` an ESM-only module → **`ERR_REQUIRE_ESM` at runtime**, thrown the moment the pro vault recovery-phrase code (`pro/main/vault/vault-recovery.ts`) loads. `tsc` / CI `verify` never catch this — a green build is not proof it loads.

## Fix

Exclude both from `externalizeDepsPlugin` so Rollup **bundles** them into the main chunk (transpiled to the output format), sidestepping the ESM/CJS boundary.

## Verified against a real build (`npm run build` with pro present)

- No `require('@scure/...')` / `@noble/...` anywhere in `out/main/` — nothing externalized.
- `generateMnemonic` + the full 2048-word BIP39 wordlist (`abandon`…`zoo`) are **inlined** in the same chunk as the recovery code.
- 11 recovery unit tests pass against the real lib.

Per CLAUDE.md's engine-verification rule (verify the exact packaged path, not an approximation), this was confirmed in the built output, not just typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application packaging so required cryptography libraries are bundled with the app, helping prevent startup or runtime issues in the desktop build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->