### PR TITLE
fix(updater): publish to the current repo name (off-grid-ai-desktop)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -79,6 +79,9 @@ electronFuses:
 publish:
   provider: github
   owner: off-grid-ai
-  repo: desktop
+  # Current repo name. It was renamed from `desktop`; the old name still 301-redirects,
+  # but the updater must not depend on that redirect (a new `off-grid-ai/desktop` repo
+  # would silently break every client's update check). Point straight at the real repo.
+  repo: off-grid-ai-desktop
   # Publish (not draft) so electron-updater on installed apps sees the release.
   releaseType: release

--- a/src/main/__tests__/updater-publish.test.ts
+++ b/src/main/__tests__/updater-publish.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Regression guard for the auto-updater publish target. The repo was renamed from
+ * `desktop` to `off-grid-ai-desktop`; the old name only works via GitHub's 301
+ * rename-redirect, and depending on that silently breaks every client's update
+ * check the day a new `off-grid-ai/desktop` repo is created. Assert the publish
+ * config points at the real repo name — read from source, like the prompt guards.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const yml = readFileSync(new URL('../../../electron-builder.yml', import.meta.url), 'utf8');
+
+describe('electron-builder publish target', () => {
+  it('publishes to owner off-grid-ai', () => {
+    expect(yml).toMatch(/owner:\s*off-grid-ai\b/);
+  });
+
+  it('uses the current repo name, not the redirect-only old name', () => {
+    expect(yml).toMatch(/repo:\s*off-grid-ai-desktop\b/);
+    // The bare old name (`repo: desktop`) must not come back.
+    expect(yml).not.toMatch(/^\s*repo:\s*desktop\s*$/m);
+  });
+});


### PR DESCRIPTION
## What triggered this
An updater error in beta.56:
> Could not check: Cannot find latest-mac.yml … `off-grid-ai/desktop/releases/download/v0.0.38-beta.57/latest-mac.yml`: HttpError: 404

Two findings:

### The 404 itself is transient
It happened because beta.57's build was **still uploading** — `latest-mac.yml` (and the zip) publish at the *end* of the run; only the `.dmg` was up when the check fired. Verified: for a *completed* release (beta.56) that exact URL 301-redirects to `off-grid-ai-desktop` and returns **200**. No code change fixes the transient case; it clears when the build finishes.

### The real latent bug (this PR)
`electron-builder.yml` still had `repo: desktop` — the repo's **old** name. It only works via GitHub's rename **301 redirect**. That's fragile: the day anyone creates a new `off-grid-ai/desktop` repo, the redirect disappears and **every installed client's update check 404s**. Point the publish target straight at the real repo, `off-grid-ai-desktop`.

Old installed builds keep working (they query `desktop` → redirect); new builds query `off-grid-ai-desktop` directly.

## Test
`updater-publish` guard reads `electron-builder.yml` and asserts `repo: off-grid-ai-desktop` (and that the bare `repo: desktop` can't return). 2 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s update publishing setup to point to the correct GitHub repository for releases.

* **Tests**
  * Added a regression test to verify the update configuration continues using the expected repository name and avoids the deprecated redirect-only path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->