### PR TITLE
ci: announce every release in Slack (link + notes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,13 +271,12 @@ jobs:
 
       # Announce every published release in Slack: the GitHub release link + the notes
       # generated above. Fail-soft (scripts/notify-slack-release.mjs always exits 0), so a
-      # Slack outage never fails a release. Needs org/repo secret SLACK_BOT_TOKEN (a bot with
-      # chat:write, invited to the channel). No token => the step is a logged no-op.
+      # Slack outage never fails a release. Needs org/repo secret SLACK_WEBHOOK_URL (an
+      # Incoming Webhook, channel-bound). No secret => the step is a logged no-op.
       - name: Announce release in Slack
         if: success()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          SLACK_CHANNEL: C0AFARY80HJ
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           PRODUCT: Off Grid AI Desktop
           VERSION: ${{ needs.version.outputs.version }}
           CHANNEL_LABEL: ${{ needs.version.outputs.channel }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,3 +268,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.version.outputs.version }}
         run: gh release edit "v$VERSION" --notes-file release-notes.md
+
+      # Announce every published release in Slack: the GitHub release link + the notes
+      # generated above. Fail-soft (scripts/notify-slack-release.mjs always exits 0), so a
+      # Slack outage never fails a release. Needs org/repo secret SLACK_BOT_TOKEN (a bot with
+      # chat:write, invited to the channel). No token => the step is a logged no-op.
+      - name: Announce release in Slack
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: C0AFARY80HJ
+          PRODUCT: Off Grid AI Desktop
+          VERSION: ${{ needs.version.outputs.version }}
+          CHANNEL_LABEL: ${{ needs.version.outputs.channel }}
+          NOTES_FILE: release-notes.md
+          RELEASE_URL: https://github.com/off-grid-ai/off-grid-ai-desktop/releases/tag/v${{ needs.version.outputs.version }}
+        run: node scripts/notify-slack-release.mjs

--- a/scripts/notify-slack-release.mjs
+++ b/scripts/notify-slack-release.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Announce a published release to Slack. Called as the LAST step of each release workflow
+// (desktop + mobile android/ios) so a message lands in the release channel on every release.
+//
+// Single responsibility: read the already-generated release notes + a few env facts and post
+// one chat.postMessage. It NEVER fails the release — a missing token, an unreachable Slack, or a
+// non-ok response logs a warning and exits 0. The posting logic lives here once; each workflow
+// just sets env and runs it.
+//
+// Env:
+//   SLACK_BOT_TOKEN  (required — absent => no-op, exit 0)   bot needs chat:write + be in the channel
+//   SLACK_CHANNEL    (default C0AFARY80HJ)
+//   PRODUCT          e.g. "Off Grid AI Desktop"
+//   VERSION          e.g. "0.0.39-beta.63"
+//   CHANNEL_LABEL    "beta" | "stable" (optional, shown as a tag)
+//   NOTES_FILE       (default release-notes.md)
+//   RELEASE_URL      (optional; default derived from GITHUB_SERVER_URL/GITHUB_REPOSITORY + tag)
+import { readFileSync } from 'node:fs';
+
+const warn = (m) => console.warn(`[slack-release] ${m}`);
+
+const token = process.env.SLACK_BOT_TOKEN;
+if (!token) { warn('SLACK_BOT_TOKEN not set — skipping announcement (no-op).'); process.exit(0); }
+
+const channel = process.env.SLACK_CHANNEL || 'C0AFARY80HJ';
+const product = process.env.PRODUCT || 'Off Grid AI';
+const version = process.env.VERSION || '';
+const label = (process.env.CHANNEL_LABEL || '').trim();
+const notesFile = process.env.NOTES_FILE || 'release-notes.md';
+
+const server = process.env.GITHUB_SERVER_URL || 'https://github.com';
+const repo = process.env.GITHUB_REPOSITORY || '';
+const releaseUrl = process.env.RELEASE_URL || (repo && version ? `${server}/${repo}/releases/tag/v${version}` : '');
+
+let notes = '';
+try { notes = readFileSync(notesFile, 'utf8').trim(); } catch { /* notes optional */ }
+// Slack section text caps at 3000 chars; keep well under and never dump a wall.
+if (notes.length > 2600) { notes = `${notes.slice(0, 2600)}\n…`; }
+
+const tag = label ? `  \`${label}\`` : '';
+const header = `:package:  *${product}*  \`${version || 'release'}\`${tag}`;
+const linkLine = releaseUrl ? `<${releaseUrl}|Download / release page>` : '';
+const body = notes || '_No release notes generated for this build._';
+
+const blocks = [
+  { type: 'section', text: { type: 'mrkdwn', text: header } },
+  { type: 'section', text: { type: 'mrkdwn', text: body } },
+];
+if (linkLine) { blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: linkLine }] }); }
+
+try {
+  const res = await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json; charset=utf-8', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ channel, text: `${product} ${version} released`, blocks, unfurl_links: false }),
+  });
+  const j = await res.json().catch(() => ({}));
+  if (!res.ok || !j.ok) { warn(`chat.postMessage not ok: HTTP ${res.status} ${j.error || ''}`); process.exit(0); }
+  console.log(`[slack-release] announced ${product} ${version} to ${channel} (ts=${j.ts})`);
+} catch (e) {
+  warn(`post failed: ${e?.message || e}`);
+}
+process.exit(0);

--- a/scripts/notify-slack-release.mjs
+++ b/scripts/notify-slack-release.mjs
@@ -35,15 +35,20 @@ const server = process.env.GITHUB_SERVER_URL || 'https://github.com';
 const repo = process.env.GITHUB_REPOSITORY || '';
 const releaseUrl = process.env.RELEASE_URL || (repo && version ? `${server}/${repo}/releases/tag/v${version}` : '');
 
+// Slack mrkdwn reserves & < > — a raw commit subject containing them (release notes are raw
+// commit subjects) would misrender or be read as a <link|mention>. Escape the note body only;
+// NOT the intentional <url|label> link line below.
+const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
 let notes = '';
 try { notes = readFileSync(notesFile, 'utf8').trim(); } catch { /* notes optional */ }
 // Slack section text caps at 3000 chars; keep well under and never dump a wall.
 if (notes.length > 2600) { notes = `${notes.slice(0, 2600)}\n…`; }
 
 const tag = label ? `  \`${label}\`` : '';
-const header = `:package:  *${product}*  \`${version || 'release'}\`${tag}`;
+const header = `:package:  *${esc(product)}*  \`${version || 'release'}\`${tag}`;
 const linkLine = releaseUrl ? `<${releaseUrl}|Download / release page>` : '';
-const body = notes || '_No release notes generated for this build._';
+const body = notes ? esc(notes) : '_No release notes generated for this build._';
 
 const blocks = [
   { type: 'section', text: { type: 'mrkdwn', text: header } },
@@ -59,6 +64,7 @@ try {
       method: 'POST',
       headers: { 'Content-Type': 'application/json; charset=utf-8' },
       body: JSON.stringify({ text: fallbackText, blocks, unfurl_links: false }),
+      signal: AbortSignal.timeout(10000),
     });
     const t = await res.text().catch(() => '');
     if (!res.ok) { warn(`webhook not ok: HTTP ${res.status} ${t}`); process.exit(0); }
@@ -68,6 +74,7 @@ try {
       method: 'POST',
       headers: { 'Content-Type': 'application/json; charset=utf-8', Authorization: `Bearer ${token}` },
       body: JSON.stringify({ channel, text: fallbackText, blocks, unfurl_links: false }),
+      signal: AbortSignal.timeout(10000),
     });
     const j = await res.json().catch(() => ({}));
     if (!res.ok || !j.ok) { warn(`chat.postMessage not ok: HTTP ${res.status} ${j.error || ''}`); process.exit(0); }

--- a/scripts/notify-slack-release.mjs
+++ b/scripts/notify-slack-release.mjs
@@ -7,9 +7,11 @@
 // non-ok response logs a warning and exits 0. The posting logic lives here once; each workflow
 // just sets env and runs it.
 //
-// Env:
-//   SLACK_BOT_TOKEN  (required — absent => no-op, exit 0)   bot needs chat:write + be in the channel
-//   SLACK_CHANNEL    (default C0AFARY80HJ)
+// Delivery (either works; webhook wins if both set):
+//   SLACK_WEBHOOK_URL  an Incoming Webhook (channel-bound — no token/scope/channel needed)
+//   SLACK_BOT_TOKEN    a Bot User OAuth token (xoxb-…, chat:write) + SLACK_CHANNEL
+//   With neither set => no-op, exit 0.
+// Content env:
 //   PRODUCT          e.g. "Off Grid AI Desktop"
 //   VERSION          e.g. "0.0.39-beta.63"
 //   CHANNEL_LABEL    "beta" | "stable" (optional, shown as a tag)
@@ -19,8 +21,9 @@ import { readFileSync } from 'node:fs';
 
 const warn = (m) => console.warn(`[slack-release] ${m}`);
 
+const webhook = process.env.SLACK_WEBHOOK_URL;
 const token = process.env.SLACK_BOT_TOKEN;
-if (!token) { warn('SLACK_BOT_TOKEN not set — skipping announcement (no-op).'); process.exit(0); }
+if (!webhook && !token) { warn('no SLACK_WEBHOOK_URL or SLACK_BOT_TOKEN set — skipping announcement (no-op).'); process.exit(0); }
 
 const channel = process.env.SLACK_CHANNEL || 'C0AFARY80HJ';
 const product = process.env.PRODUCT || 'Off Grid AI';
@@ -48,15 +51,28 @@ const blocks = [
 ];
 if (linkLine) { blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: linkLine }] }); }
 
+const fallbackText = `${product} ${version} released`;
 try {
-  const res = await fetch('https://slack.com/api/chat.postMessage', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json; charset=utf-8', Authorization: `Bearer ${token}` },
-    body: JSON.stringify({ channel, text: `${product} ${version} released`, blocks, unfurl_links: false }),
-  });
-  const j = await res.json().catch(() => ({}));
-  if (!res.ok || !j.ok) { warn(`chat.postMessage not ok: HTTP ${res.status} ${j.error || ''}`); process.exit(0); }
-  console.log(`[slack-release] announced ${product} ${version} to ${channel} (ts=${j.ts})`);
+  if (webhook) {
+    // Incoming webhook: channel is fixed by the hook; POST the blocks, expect body "ok".
+    const res = await fetch(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      body: JSON.stringify({ text: fallbackText, blocks, unfurl_links: false }),
+    });
+    const t = await res.text().catch(() => '');
+    if (!res.ok) { warn(`webhook not ok: HTTP ${res.status} ${t}`); process.exit(0); }
+    console.log(`[slack-release] announced ${product} ${version} via webhook`);
+  } else {
+    const res = await fetch('https://slack.com/api/chat.postMessage', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json; charset=utf-8', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ channel, text: fallbackText, blocks, unfurl_links: false }),
+    });
+    const j = await res.json().catch(() => ({}));
+    if (!res.ok || !j.ok) { warn(`chat.postMessage not ok: HTTP ${res.status} ${j.error || ''}`); process.exit(0); }
+    console.log(`[slack-release] announced ${product} ${version} to ${channel} (ts=${j.ts})`);
+  }
 } catch (e) {
   warn(`post failed: ${e?.message || e}`);
 }


### PR DESCRIPTION
Posts to the release Slack channel (`C0AFARY80HJ`) on every OGAD release — the GitHub release link + the notes already generated by `scripts/release-notes.mjs`.

- New `scripts/notify-slack-release.mjs`: single responsibility, **fail-soft** (always exits 0, so a Slack outage never fails a release). Verified locally: no-token => logged no-op; a bad token reaches the real Slack API (`HTTP 200 invalid_auth`) and still exits 0.
- Wired as the last step of `release.yml` (`if: success()`), for both beta and stable.

**Setup required:** add repo/org secret `SLACK_BOT_TOKEN` — a **Bot User OAuth Token** (`xoxb-…` from OAuth & Permissions) with `chat:write`, and invite the bot to the channel. Without it the step is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic Slack release announcement after successful releases.
  * Announcements include product name, resolved version/channel, truncated release notes when available, and a link to the published release.

* **Bug Fixes**
  * Made Slack notifications best-effort: missing Slack settings or delivery/posting errors no longer affect the release.
  * Ensures release notes fit within Slack message limits for safer delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->