### PR TITLE
ci(release): attach release notes for beta too, not just stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,11 +259,12 @@ jobs:
             gh release create nightly --prerelease --title "Nightly (rolling)" \
               --notes "Rolling nightly build, auto-updated on every change. Pre-release — expect rough edges. Stable: https://github.com/off-grid-ai/off-grid-ai-desktop/releases/latest"
           gh release upload nightly dist/OffGrid-nightly.dmg --clobber
-      # electron-builder creates the GitHub release with empty notes; attach the
-      # notes generated above (mobile sets them at create time via --notes-file; the
-      # desktop release is created by electron-builder, so we set them after).
+      # electron-builder creates the GitHub release with empty notes; attach the notes
+      # generated above. Runs for BOTH channels (beta + stable) — the notes file and the
+      # v$VERSION tag exist for beta too, so beta/nightly releases get their changelog on
+      # the release page, not just stable.
       - name: Attach release notes
-        if: needs.version.outputs.channel == 'stable'
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
One-line gate change: the 'Attach release notes' step now runs for both channels. The notes file + `v$VERSION` tag already exist for beta, so beta/nightly releases get their changelog on the GitHub release page (was empty for beta — why `v0.0.39-beta.63` needed a manual attach). Slack already posts notes for both; this makes the GitHub release page match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release notes are now attached to both beta and stable GitHub releases, so changelogs appear consistently on the release page.
  * Updated release messaging to reflect that non-stable releases also include changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->