### PR TITLE
fix(packaging): accept llama.cpp b9838 --help format in packaged-helper probe

### DIFF
--- a/scripts/probe-packaged-helpers.mjs
+++ b/scripts/probe-packaged-helpers.mjs
@@ -22,7 +22,10 @@ const probes = [
     name: 'llama-server',
     relative: 'bin/llama/llama-server',
     args: ['--help'],
-    output: /(?:usage:.*llama-server|llama-server.*options)/is,
+    // llama.cpp b9838+ dropped the "usage: llama-server [options]" banner; --help now leads
+    // with "----- common params -----" and a flag list (e.g. the LLAMA_ARG_THREADS env note).
+    // Match the current format and keep the legacy banner so an older engine still passes.
+    output: /-+\s*common params|--help,\s*--usage|LLAMA_ARG_THREADS|usage:.*llama-server/is,
     libraryPath: true
   },
   {

--- a/src/main/__tests__/packaged-helper-probe.integration.test.ts
+++ b/src/main/__tests__/packaged-helper-probe.integration.test.ts
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
   if (failure && strcmp(failure, name) == 0) return 70;
   const char *hang = getenv("OFFGRID_HELPER_FIXTURE_HANG");
   if (hang && strcmp(hang, name) == 0) while (1) {}
-  if (strcmp(name, "llama-server") == 0) puts("usage: llama-server [options]");
+  if (strcmp(name, "llama-server") == 0) puts("----- common params -----\n-h, --help, --usage    print usage and exit\n-t, --threads N    number of CPU threads (env: LLAMA_ARG_THREADS)");
   else if (strcmp(name, "ffmpeg") == 0) puts("ffmpeg version 6.0-fixture");
   else if (strcmp(name, "whisper-cli") == 0) puts("usage: whisper-cli [options] file\noptions:");
   else if (strcmp(name, "sd-server") == 0) puts("stable-diffusion.cpp version fixture\nUsage: sd-server [options]");


### PR DESCRIPTION
## What
The release-gate packaged-helper probe (`scripts/probe-packaged-helpers.mjs`) runs the packaged `llama-server --help` and matched `/usage:.*llama-server/`. **llama.cpp b9838 dropped that banner** — `--help` now leads with `----- common params -----` and a flag list — so the probe rejected a working engine ('produced no recognized real output') and **blocked publication of an already signed + notarized DMG** (`0.0.41-beta.67`).

## Fix
- Matcher now accepts the current format (`common params` / `--help, --usage` / `LLAMA_ARG_THREADS`) and keeps the legacy banner so an older engine still passes.
- Test fixture updated to emit the real b9838 `--help` so the integration test guards the **shipped** format instead of a stale string (the old fixture is why CI stayed green while the real binary failed the release probe).

## Evidence
- Regex vs real b9838 output: matches ✓ | legacy banner: matches ✓ | empty/silent: rejected ✓
- `packaged-helper-probe.integration.test.ts`: 7/7 pass
- Prior release run proved signing + notarization + DMG integrity already green; this was the only blocker at step 16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaged-helper detection to recognize both legacy and current `llama-server` help output formats.
  * Updated integration coverage for help text containing common parameters, usage options, and thread settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->