### PR TITLE
fix(release): unblock nightly publish (feed) + LFS bandwidth diet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,12 +94,17 @@ jobs:
         with:
           ref: ${{ needs.version.outputs.sha }} # the exact bumped commit
           fetch-depth: 0
-          lfs:
-            true # resources/bin/* (llama-server, sd-cli, whisper, ffmpeg, dylibs)
-            # are Git LFS — without this CI bundles pointer stubs and every
-            # runtime spawn fails with ENOEXEC.
-      - name: Pull LFS binaries
-        run: git lfs pull
+          lfs: false # Smudge nothing on checkout; pull only the shipped, non-rebuilt
+            # binaries below. Fetching everything (~200 MB) blew the org's monthly LFS
+            # bandwidth budget and failed the release checkout ("exceeded its LFS budget").
+      - name: Pull shipped LFS binaries (skip the ones rebuilt below)
+        # resources/bin/{ffmpeg,text-extractor,sd/**,LICENSE} are prebuilt and shipped
+        # as-is, so they MUST be real files — a pointer stub spawns as ENOEXEC at runtime.
+        # llama/ + whisper/ are excluded because build-llama.sh / build-whisper-cli.sh
+        # recompile them from source in place later in this job, so pulling the committed
+        # copies is wasted bandwidth. The packaged-helper probe (ffmpeg/sd/whisper/llama)
+        # fails the release if any shipped binary is missing, so a bad exclude can't ship.
+        run: git lfs pull --exclude="resources/bin/llama,resources/bin/whisper"
       # Rebuild the chat engine from source with a PINNED macOS deployment target.
       # The committed/LFS llama-server is minos 26 (built on a macOS-26 toolchain),
       # so it only launches on macOS 26 — every macOS 13/14/15 user saw "Chat model

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,9 @@ jobs:
             # A nightly is a prerelease of the NEXT patch, so it sorts ABOVE the last
             # stable, not below it: 0.0.35 stable -> 0.0.36-beta.<run> (NOT
             # 0.0.35-beta.<run>, which semver ranks BELOW 0.0.35 and would read as a
-            # downgrade). electron-builder turns the -beta suffix into the `beta`
-            # channel (beta-mac.yml) automatically. No commit.
+            # downgrade). The -beta suffix marks the GitHub release as a prerelease;
+            # the update feed itself is always latest-mac.yml (no publish.channel set).
+            # No commit.
             BASE=$(node -p "require('./package.json').version")
             BASE=${BASE%%-*}
             NEXT=$(node -e "const p='$BASE'.split('.').map(Number); console.log(p[0]+'.'+p[1]+'.'+(p[2]+1))")
@@ -178,7 +179,8 @@ jobs:
       # Stamp the resolved version into package.json so electron-builder picks the
       # right channel. For stable this matches the committed bump (no-op); for beta
       # it applies the -beta.<run> version (no commit needed — this checkout is
-      # throwaway). The -beta suffix is what makes electron-builder write beta-mac.yml.
+      # throwaway). The -beta suffix marks the release prerelease; the feed stays
+      # latest-mac.yml (electron-builder emits no beta-mac.yml without publish.channel).
       - name: Stamp build version
         run: npm version "${{ needs.version.outputs.version }}" --no-git-tag-version --allow-same-version
       - name: Build (typecheck + bundle)
@@ -228,11 +230,15 @@ jobs:
           CHANNEL: ${{ needs.version.outputs.channel }}
           TARGET_SHA: ${{ needs.version.outputs.sha }}
         run: |
-          if [ "$CHANNEL" = stable ]; then
-            FEED=latest-mac.yml
-          else
-            FEED=beta-mac.yml
-          fi
+          # electron-builder writes ONE update feed, latest-mac.yml, for BOTH channels
+          # (we set no publish.channel, so it never emits beta-mac.yml). Beta vs stable
+          # is expressed by the release's prerelease flag + electron-updater's
+          # allowPrerelease on the client, NOT by a distinct feed filename — every
+          # shipped beta used latest-mac.yml (e.g. 0.0.39-beta.66), and the pro-mac.yml
+          # migration below copies from latest-mac.yml on the beta path too. A prior
+          # refactor assumed a beta-mac.yml that is never generated, so `test -f` aborted
+          # every nightly publish under `set -e` with no output.
+          FEED=latest-mac.yml
           test -f "dist/$FEED"
           node scripts/prepare-mac-release-assets.mjs \
             "dist/$FEED" dist dist/release-assets "$VERSION"

--- a/resources/bin/libggml-base.0.9.5.dylib
+++ b/resources/bin/libggml-base.0.9.5.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb4f4898fcb5eb8c97eec3ee36e6bc3ab4c7cabf732eddefb96b58f1cbbd6ed6
-size 669384

--- a/resources/bin/libggml-base.0.dylib
+++ b/resources/bin/libggml-base.0.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb4f4898fcb5eb8c97eec3ee36e6bc3ab4c7cabf732eddefb96b58f1cbbd6ed6
-size 669384

--- a/resources/bin/libggml-base.dylib
+++ b/resources/bin/libggml-base.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb4f4898fcb5eb8c97eec3ee36e6bc3ab4c7cabf732eddefb96b58f1cbbd6ed6
-size 669384

--- a/resources/bin/libggml-blas.0.9.5.dylib
+++ b/resources/bin/libggml-blas.0.9.5.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8f6fe3d9fe0efc4efd5d19bf3861fbcaeea786dc0a2a651c19aec4610bb059f
-size 58536

--- a/resources/bin/libggml-blas.0.dylib
+++ b/resources/bin/libggml-blas.0.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8f6fe3d9fe0efc4efd5d19bf3861fbcaeea786dc0a2a651c19aec4610bb059f
-size 58536

--- a/resources/bin/libggml-blas.dylib
+++ b/resources/bin/libggml-blas.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8f6fe3d9fe0efc4efd5d19bf3861fbcaeea786dc0a2a651c19aec4610bb059f
-size 58536

--- a/resources/bin/libggml-cpu.0.9.5.dylib
+++ b/resources/bin/libggml-cpu.0.9.5.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f0da67d29b3dfb2f7f8191a19ffd82a7c8740def230412848a250da93b59141
-size 786680

--- a/resources/bin/libggml-cpu.0.dylib
+++ b/resources/bin/libggml-cpu.0.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f0da67d29b3dfb2f7f8191a19ffd82a7c8740def230412848a250da93b59141
-size 786680

--- a/resources/bin/libggml-cpu.dylib
+++ b/resources/bin/libggml-cpu.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f0da67d29b3dfb2f7f8191a19ffd82a7c8740def230412848a250da93b59141
-size 786680

--- a/resources/bin/libggml-metal.0.9.5.dylib
+++ b/resources/bin/libggml-metal.0.9.5.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53761f4df32546b9806806ce263549566c2a39a1d32b79b6304941d7c69e9acf
-size 760504

--- a/resources/bin/libggml-metal.0.dylib
+++ b/resources/bin/libggml-metal.0.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53761f4df32546b9806806ce263549566c2a39a1d32b79b6304941d7c69e9acf
-size 760504

--- a/resources/bin/libggml-metal.dylib
+++ b/resources/bin/libggml-metal.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53761f4df32546b9806806ce263549566c2a39a1d32b79b6304941d7c69e9acf
-size 760504

--- a/resources/bin/libggml-rpc.0.9.5.dylib
+++ b/resources/bin/libggml-rpc.0.9.5.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5b13bed597fff03c075cf8689827cf1aeb1d45d07afbe130ca827e903d22ef1
-size 129976

--- a/resources/bin/libggml-rpc.0.dylib
+++ b/resources/bin/libggml-rpc.0.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5b13bed597fff03c075cf8689827cf1aeb1d45d07afbe130ca827e903d22ef1
-size 129976

--- a/resources/bin/libggml-rpc.dylib
+++ b/resources/bin/libggml-rpc.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5b13bed597fff03c075cf8689827cf1aeb1d45d07afbe130ca827e903d22ef1
-size 129976

--- a/resources/bin/libggml.0.9.5.dylib
+++ b/resources/bin/libggml.0.9.5.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c466ea5372caabaf391b4850c4a46bd87ec9855e45413417b3f182167d18a674
-size 59696

--- a/resources/bin/libggml.0.dylib
+++ b/resources/bin/libggml.0.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c466ea5372caabaf391b4850c4a46bd87ec9855e45413417b3f182167d18a674
-size 59696

--- a/resources/bin/libggml.dylib
+++ b/resources/bin/libggml.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c466ea5372caabaf391b4850c4a46bd87ec9855e45413417b3f182167d18a674
-size 59696

--- a/resources/bin/libllama.0.0.7769.dylib
+++ b/resources/bin/libllama.0.0.7769.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d32287456814d0a238845ba1c7bfeaaaa098fe9eb4c05c9272329ea9b2469cd3
-size 2162696

--- a/resources/bin/libllama.0.dylib
+++ b/resources/bin/libllama.0.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d32287456814d0a238845ba1c7bfeaaaa098fe9eb4c05c9272329ea9b2469cd3
-size 2162696

--- a/resources/bin/libllama.dylib
+++ b/resources/bin/libllama.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d32287456814d0a238845ba1c7bfeaaaa098fe9eb4c05c9272329ea9b2469cd3
-size 2162696

--- a/resources/bin/libmtmd.0.0.7769.dylib
+++ b/resources/bin/libmtmd.0.0.7769.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68d09831d779e75c0edd376d4ce0cc45d581d0e462eee9e96ada635f07d44368
-size 736936

--- a/resources/bin/libmtmd.0.dylib
+++ b/resources/bin/libmtmd.0.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68d09831d779e75c0edd376d4ce0cc45d581d0e462eee9e96ada635f07d44368
-size 736936

--- a/resources/bin/libmtmd.dylib
+++ b/resources/bin/libmtmd.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68d09831d779e75c0edd376d4ce0cc45d581d0e462eee9e96ada635f07d44368
-size 736936

--- a/resources/bin/llama-batched-bench
+++ b/resources/bin/llama-batched-bench
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c33136482ff00c8439cdc03b2c52e8242370415de5caeb7b2f8779d527c8f9e0
-size 6923328

--- a/resources/bin/llama-bench
+++ b/resources/bin/llama-bench
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24f433f9e3aab802b0477bfcf28c3f188aa6b0eb1e3b62b6da5927e95deef3a3
-size 458680

--- a/resources/bin/llama-cli
+++ b/resources/bin/llama-cli
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5bb2b869e411977fb0acdc0af8d5eb43334179752074d1a94ee8ebd7a13483f5
-size 7845912

--- a/resources/bin/llama-completion
+++ b/resources/bin/llama-completion
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73a1309a113107efe51bd0209023c92dc0856570cf7bd94735b9b2174e12ebc9
-size 6978448

--- a/resources/bin/llama-cvector-generator
+++ b/resources/bin/llama-cvector-generator
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a64fa390b77ad52a1959b9dff213f95f4afa60f3862105af049c2a14c4ef110
-size 6945416

--- a/resources/bin/llama-export-lora
+++ b/resources/bin/llama-export-lora
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a73fc084b907a6f772e5f45d33c691d25371f87913b5c8607485a8047ce234bd
-size 6946560

--- a/resources/bin/llama-fit-params
+++ b/resources/bin/llama-fit-params
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c0862cc4243bcdb2cc73035297cedd6a025ec410a01ef858479d5374fa3a8067
-size 6922864

--- a/resources/bin/llama-gemma3-cli
+++ b/resources/bin/llama-gemma3-cli
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:142b6273dc2155687e617bc4c5dcb86c537bd4ef60b225cf81a4b1f44b4d8bb7
-size 35472

--- a/resources/bin/llama-gguf-split
+++ b/resources/bin/llama-gguf-split
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a6ba17ddf7e2dc7f3a338664be831be6454d6da501383cf5fd8a55659b3b3183
-size 76064

--- a/resources/bin/llama-imatrix
+++ b/resources/bin/llama-imatrix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc386f3fa32c7afa8d7a0dc114c840e40bd463809fa8b6e00152bc3b551e3d96
-size 7004032

--- a/resources/bin/llama-llava-cli
+++ b/resources/bin/llama-llava-cli
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0fc0b600ca97934e79280b6c637a122139be11936ecf755163ed82068ed4d91
-size 35472

--- a/resources/bin/llama-minicpmv-cli
+++ b/resources/bin/llama-minicpmv-cli
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30e2deebbdbd83deaf3357a7654f6364f599e90445ff6a921e295c36cff30c22
-size 35472

--- a/resources/bin/llama-mtmd-cli
+++ b/resources/bin/llama-mtmd-cli
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:062595486126cb8bc10b9bf5ebd71c632ee453a19023602d9a65cb93c2d81b51
-size 6964032

--- a/resources/bin/llama-perplexity
+++ b/resources/bin/llama-perplexity
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e289007048c1dee5bc45c656d17693320d1e63db0f338eba549be20d0db2daf
-size 6998064

--- a/resources/bin/llama-quantize
+++ b/resources/bin/llama-quantize
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9b27ae78388cd4e0faf21533976536711236ea71d8abb0934eae4bac2810788
-size 335792

--- a/resources/bin/llama-qwen2vl-cli
+++ b/resources/bin/llama-qwen2vl-cli
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef2532fdab0a6d90774513ea2b142f3ea9667dcdbca96e206433e09338016b49
-size 35472

--- a/resources/bin/llama-tokenize
+++ b/resources/bin/llama-tokenize
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:efee7795286c36bc9fa7b0fb447017d0033340f3748c5e52cca1ea1c6f42ca84
-size 294368

--- a/resources/bin/llama-tts
+++ b/resources/bin/llama-tts
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1440eaf908d8a8f8d3632e96ada729e3771c2f72ed8d7070e314169a93d9ba74
-size 7028104

--- a/resources/bin/rpc-server
+++ b/resources/bin/rpc-server
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49a98b0254d928ffa27f654e576ba67bc76084383ca77db0194637a57775869a
-size 131848


### PR DESCRIPTION
Two release.yml fixes needed for a clean, publishable nightly. Both landed here since both are release.yml corrections that should ship together.

## 1. fix(release): nightly publish was aborting on a non-existent feed file
The mac publish step branched `FEED=beta-mac.yml` for the beta channel and ran `test -f dist/beta-mac.yml` under `set -e`. **electron-builder never emits `beta-mac.yml`** (no `publish.channel` is set — it always writes `latest-mac.yml`), so that test failed instantly with no output and aborted **every** nightly publish — right after a fully signed + notarized DMG passed the install smoke (8/8). Beta vs stable is the release's prerelease flag + electron-updater `allowPrerelease`, not a feed filename; every shipped beta (`0.0.39-beta.66`) used `latest-mac.yml`, and `pro-mac.yml` already copies from `latest-mac.yml` on the beta path. Fix: use `latest-mac.yml` for both channels + correct the two comments that wrongly claimed `-beta` makes electron-builder emit `beta-mac.yml`. build-win unaffected (uses `--publish always`).

## 2. chore(release): LFS bandwidth diet (−130 MB/build, −88 MB app)
The org's monthly Git LFS **bandwidth** (10 GB, shared, not free on public repos) was exhausted and failed the release checkout. Deleted 43 **stale duplicate** flat binaries (old `libggml 0.9.5`/`libllama 0.0.7769` from before the engine moved into `resources/bin/llama/`; verified zero references, `fs.existsSync`-guarded, subdir preferred). Kept ffmpeg/text-extractor/dictation-hotkey/meeting-recorder. Checkout now `lfs: false` + targeted pull excluding `llama/`+`whisper/` (recompiled in-job). Per-release LFS ~295 MB → ~165 MB; app 88 MB smaller; LFS files 85 → 42.

## Safety
The dependency-closure gate + packaged-helper probe fail the release if any shipped binary is missing, so a wrong exclude can't ship broken. helper-probe test 7/7. release.yml YAML validated.