### PR TITLE
fix(update): never auto-offer an older stable to a beta build

### DIFF
--- a/src/main/__tests__/update-channel.test.ts
+++ b/src/main/__tests__/update-channel.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { resolveChannelConfig } from '../update-channel'
+
+// Regression guard for the "beta app offered an OLDER stable as an update" bug: a
+// running 0.0.41-beta.69 was shown "Update 0.0.38 is ready" because applyChannel set
+// allowDowngrade=true unconditionally (and pointed beta at a beta-mac.yml we never
+// publish). The channel decision is now pure — assert its real output.
+describe('resolveChannelConfig', () => {
+  it('stable: single latest feed, no prerelease, no downgrade on routine checks', () => {
+    expect(resolveChannelConfig('stable')).toEqual({
+      channel: 'latest',
+      allowPrerelease: false,
+      allowDowngrade: false
+    })
+  })
+
+  it('beta: same latest feed + prerelease, but STILL no downgrade on routine checks', () => {
+    // The core fix: a beta build must never be auto-"updated" to an older stable.
+    expect(resolveChannelConfig('beta')).toEqual({
+      channel: 'latest',
+      allowPrerelease: true,
+      allowDowngrade: false
+    })
+  })
+
+  it('never targets a beta-mac.yml feed — we publish only latest-mac.yml', () => {
+    expect(resolveChannelConfig('beta').channel).toBe('latest')
+    expect(resolveChannelConfig('stable').channel).toBe('latest')
+  })
+
+  it('permits a downgrade ONLY on an explicit channel switch (beta → stable graduation)', () => {
+    expect(resolveChannelConfig('stable', true).allowDowngrade).toBe(true)
+    expect(resolveChannelConfig('beta', true).allowDowngrade).toBe(true)
+    // The prerelease/feed knobs are unchanged by the explicit-switch flag.
+    expect(resolveChannelConfig('beta', true).allowPrerelease).toBe(true)
+    expect(resolveChannelConfig('stable', true).allowPrerelease).toBe(false)
+  })
+})

--- a/src/main/__tests__/updater.test.ts
+++ b/src/main/__tests__/updater.test.ts
@@ -96,6 +96,16 @@ describe('software-update settings flow: manual check + auto toggle', () => {
     expect(indexSrc).toMatch(/if\s*\(\s*!is\.dev\s*\)\s*m\.startAutoUpdates\(\)/)
   })
 
+  it('never sets allowDowngrade=true unconditionally (would offer an older stable to a beta)', () => {
+    // Regression: `autoUpdater.allowDowngrade = true` on every launch made a
+    // 0.0.41-beta.69 app accept "Update 0.0.38". The knob must come from the pure
+    // resolveChannelConfig, which only allows a downgrade on an explicit switch.
+    expect(updaterSrc).not.toMatch(/allowDowngrade\s*=\s*true/)
+    expect(updaterSrc).toMatch(/resolveChannelConfig/)
+    // Explicit channel switch is the only caller allowed to permit a downgrade.
+    expect(updaterSrc).toMatch(/applyChannel\(true\)/)
+  })
+
   it('preload bridges the check + prefs controls', () => {
     expect(preloadSrc).toMatch(
       /checkForUpdates:\s*\(\)\s*=>\s*ipcRenderer\.invoke\(\s*['"]update:check['"]/

--- a/src/main/update-channel.ts
+++ b/src/main/update-channel.ts
@@ -1,0 +1,36 @@
+// Pure resolution of electron-updater's channel knobs — deliberately free of Electron
+// and DB imports so it unit-tests directly (see update-channel.test.ts).
+//
+// We publish ONE update feed, latest-mac.yml, for BOTH channels: a beta build is just
+// a GitHub *prerelease* carrying that same feed (see release.yml). So the updater
+// channel is ALWAYS 'latest'; the only difference for beta is allowPrerelease=true so
+// the updater also considers prerelease releases. Pointing channel at 'beta' made it
+// fetch a beta-mac.yml that is never published — beta users then saw no updates.
+//
+// allowDowngrade stays FALSE on routine launch/interval checks: a beta such as
+// 0.0.41-beta.69 must never be auto-"updated" to an OLDER stable like 0.0.38 (that is
+// the "why is 0.0.38 offered on a 0.0.41 app" bug). It is true ONLY when the user
+// explicitly switches channels, so a deliberate beta -> stable move can land the
+// latest stable even though its version is numerically lower than the beta.
+
+export type UpdateChannel = 'stable' | 'beta'
+
+export interface UpdaterChannelConfig {
+  /** Always the single published feed (latest-mac.yml). */
+  channel: 'latest'
+  /** Beta also accepts prerelease releases; stable does not. */
+  allowPrerelease: boolean
+  /** Only permitted on an explicit user channel switch, never on routine checks. */
+  allowDowngrade: boolean
+}
+
+export function resolveChannelConfig(
+  pref: UpdateChannel,
+  explicitChannelSwitch = false
+): UpdaterChannelConfig {
+  return {
+    channel: 'latest',
+    allowPrerelease: pref === 'beta',
+    allowDowngrade: explicitChannelSwitch
+  }
+}

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -8,6 +8,7 @@
 import { autoUpdater } from 'electron-updater'
 import { app, BrowserWindow, ipcMain } from 'electron'
 import { getSetting, saveSetting } from './database'
+import { resolveChannelConfig, type UpdateChannel } from './update-channel'
 
 // Version of an update that finished downloading and is staged for install
 // (null = none). Held in main so a window created AFTER the download finished
@@ -20,7 +21,6 @@ function autoEnabled(): boolean {
   return getSetting<boolean>('updates:auto', true) // default ON
 }
 
-type UpdateChannel = 'stable' | 'beta'
 function channelPref(): UpdateChannel {
   return getSetting<UpdateChannel>('updates:channel', 'stable') // default stable
 }
@@ -33,15 +33,17 @@ function applyAutoPref(): void {
   autoUpdater.autoInstallOnAppQuit = on
 }
 
-// Point the updater at the chosen feed: 'beta' reads beta-mac.yml (the nightly,
-// pre-release channel — opt-in only); 'stable' reads latest-mac.yml. allowDowngrade
-// lets a user who switches beta → stable move back to the latest STABLE build even
-// though its version is "older" than the beta they were running.
-function applyChannel(): void {
-  const beta = channelPref() === 'beta'
-  autoUpdater.channel = beta ? 'beta' : 'latest'
-  autoUpdater.allowPrerelease = beta
-  autoUpdater.allowDowngrade = true
+// Apply the updater's channel knobs from the user's preference. Decision logic is the
+// pure, Electron-free resolveChannelConfig (unit-tested in update-channel.test.ts): one
+// published feed (latest-mac.yml) for both channels, beta only flips allowPrerelease,
+// and a downgrade is permitted ONLY on an explicit channel switch — never on the routine
+// launch/interval checks, so a beta build (e.g. 0.0.41-beta.69) is never auto-offered an
+// OLDER stable (0.0.38) as an "update".
+function applyChannel(explicitChannelSwitch = false): void {
+  const cfg = resolveChannelConfig(channelPref(), explicitChannelSwitch)
+  autoUpdater.channel = cfg.channel
+  autoUpdater.allowPrerelease = cfg.allowPrerelease
+  autoUpdater.allowDowngrade = cfg.allowDowngrade
 }
 
 // Register the update IPC surface. Split OUT of startAutoUpdates so it can run in
@@ -86,7 +88,9 @@ export function registerUpdateIpc(): void {
   ipcMain.handle('update:set-channel', (_e, channel: UpdateChannel) => {
     const next: UpdateChannel = channel === 'beta' ? 'beta' : 'stable'
     saveSetting('updates:channel', next)
-    applyChannel()
+    // Explicit switch: permit a cross-channel downgrade (e.g. beta → the latest,
+    // numerically-lower stable) since the user chose it. Routine checks never do.
+    applyChannel(true)
     // Always check after a channel switch so the user gets immediate feedback
     // on what's available — even if auto-updates are off.
     autoUpdater


### PR DESCRIPTION
`applyChannel()` set `autoUpdater.allowDowngrade = true` on every launch, so a running `0.0.41-beta.69` on the default stable channel (reads `latest-mac.yml` = `0.0.38`) was offered `0.0.38` as an 'update' — a downgrade. It also pointed beta users at a `beta-mac.yml` we never publish (so they got no updates).

Fix: pure, Electron-free `resolveChannelConfig` (unit-tested) — one feed (`latest-mac.yml`) for both channels, `beta` only flips `allowPrerelease`, and `allowDowngrade` is true ONLY on an explicit channel switch, never on routine checks. Ships in the next build. Tests 17/17, tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update channel handling for stable and beta releases.
  * Prevented routine update checks from downgrading installed versions.
  * Enabled downgrades only when explicitly switching update channels.
  * Preserved beta prerelease update behavior during regular checks and channel switches.

* **Tests**
  * Added regression coverage for channel selection, prerelease handling, and downgrade protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->