### PR TITLE
fix(packaging): normalize asar entry separators so build-win passes

### DIFF
--- a/scripts/lib/macos-artifact-integrity.d.mts
+++ b/scripts/lib/macos-artifact-integrity.d.mts
@@ -4,6 +4,7 @@ export const ALLOWED_ASAR_ROOTS: readonly string[]
 export const ALLOWED_ASAR_OUT_ROOTS: readonly string[]
 
 export function verifyBundlePair(referenceBundle: string, candidateBundle: string): void
+export function assertAsarEntryInventory(entries: readonly string[]): void
 export function assertAsarArchiveInventory(archive: string): void
 export function assertAsarInventory(bundle: string): void
 export function verifyDmgArtifact(dmgPath: string, referenceBundle: string): Promise<void>

--- a/scripts/lib/macos-artifact-integrity.mjs
+++ b/scripts/lib/macos-artifact-integrity.mjs
@@ -175,8 +175,15 @@ function isAllowedAsarOutEntry(entry) {
   return ALLOWED_ASAR_OUT_ROOTS.some((root) => entry === root || entry.startsWith(`${root}/`))
 }
 
-export function assertAsarArchiveInventory(archive) {
-  for (const entry of listPackage(archive)) {
+// Pure inventory check over an asar's entry list, split out so it unit-tests without
+// building a real archive. @electron/asar's listPackage returns entries with the OS
+// path separator — POSIX "/" on macOS/Linux but "\" on Windows (e.g. "\node_modules").
+// Normalize to "/" so the POSIX allowlist below holds on every build host; without it
+// EVERY entry read as an unexpected root on the Windows runner and this release gate
+// rejected an otherwise-valid app.asar (regressing the Windows build).
+export function assertAsarEntryInventory(entries) {
+  for (const rawEntry of entries) {
+    const entry = rawEntry.replace(/\\/g, '/')
     const segments = entry.split('/').filter(Boolean)
     const privateSegment = segments.find((segment) =>
       FORBIDDEN_PRIVATE_SEGMENTS.has(segment.toLowerCase())
@@ -196,6 +203,10 @@ export function assertAsarArchiveInventory(archive) {
       throw new Error(`app.asar contains unexpected application root: ${entry}`)
     }
   }
+}
+
+export function assertAsarArchiveInventory(archive) {
+  assertAsarEntryInventory(listPackage(archive))
 }
 
 export function assertAsarInventory(bundle) {

--- a/src/main/__tests__/macos-artifact-integrity.integration.test.ts
+++ b/src/main/__tests__/macos-artifact-integrity.integration.test.ts
@@ -203,6 +203,12 @@ describe('macOS artifact integrity', () => {
         assertAsarEntryInventory(['\\out\\packaged-helpers-stale\\package\\x.js'])
       ).toThrow('unexpected build output')
     })
+
+    it('still rejects a nested application bundle with Windows separators', () => {
+      expect(() =>
+        assertAsarEntryInventory(['\\out\\main\\Nested.APP\\Contents\\Info.plist'])
+      ).toThrow('nested application bundle')
+    })
   })
 
   it('enforces ASAR inventory on the real Windows artifact hook', async () => {

--- a/src/main/__tests__/macos-artifact-integrity.integration.test.ts
+++ b/src/main/__tests__/macos-artifact-integrity.integration.test.ts
@@ -8,6 +8,7 @@ import {
   ALLOWED_ASAR_ROOTS,
   ALLOWED_ASAR_OUT_ROOTS,
   REQUIRED_MAC_BUNDLE_FILES,
+  assertAsarEntryInventory,
   assertAsarInventory,
   verifyBundlePair,
   verifyZipArtifact
@@ -162,6 +163,46 @@ describe('macOS artifact integrity', () => {
     expect(() => assertAsarInventory(bundle)).toThrow(
       'app.asar contains unexpected application root: /marketing'
     )
+  })
+
+  // Regression: @electron/asar's listPackage yields OS-separator paths — backslashes on
+  // the Windows runner ("\node_modules") — so the POSIX allowlist rejected EVERY entry
+  // and failed an otherwise-valid app.asar (the build-win release regression). The pure
+  // entry check must normalize separators so an identical tree passes on either host,
+  // WITHOUT weakening the forbidden-path checks.
+  describe('assertAsarEntryInventory — cross-platform path separators', () => {
+    const POSIX_TREE = [
+      '/package.json',
+      '/out',
+      '/out/main/index.js',
+      '/out/preload/index.js',
+      '/out/renderer/index.html',
+      '/node_modules/electron/package.json'
+    ]
+    const toWindows = (entries: string[]): string[] => entries.map((e) => e.replace(/\//g, '\\'))
+
+    it('accepts a valid runtime tree with POSIX separators', () => {
+      expect(() => assertAsarEntryInventory(POSIX_TREE)).not.toThrow()
+    })
+
+    it('accepts the SAME valid tree with Windows backslash separators', () => {
+      expect(() => assertAsarEntryInventory(toWindows(POSIX_TREE))).not.toThrow()
+    })
+
+    it('still rejects an unexpected root delivered with Windows separators', () => {
+      expect(() => assertAsarEntryInventory(['\\marketing', '\\marketing\\list.csv'])).toThrow(
+        'app.asar contains unexpected application root'
+      )
+    })
+
+    it('still rejects private state + build output with Windows separators', () => {
+      expect(() => assertAsarEntryInventory(['\\out\\main\\.OFFGRID\\private.db'])).toThrow(
+        'forbidden private state'
+      )
+      expect(() =>
+        assertAsarEntryInventory(['\\out\\packaged-helpers-stale\\package\\x.js'])
+      ).toThrow('unexpected build output')
+    })
   })
 
   it('enforces ASAR inventory on the real Windows artifact hook', async () => {


### PR DESCRIPTION
`build-win` regressed (last green at ea30213 / 0.0.39-beta.66) once the ASAR-inventory gates (`04ebf28`/`187b6c5`) landed. The `artifactBuildCompleted` gate `assertAsarArchiveInventory` runs on every platform, but `@electron/asar`'s `listPackage` returns OS-separator paths — backslashes on the Windows runner (`\\node_modules`) — while the allowlist is POSIX (`/node_modules`). Every entry read as an unexpected root and the gate failed a valid app.asar.

Fix: extract a pure `assertAsarEntryInventory` that normalizes `\\`→`/` before the checks. Tests cover a valid tree in BOTH separators + that forbidden roots/private-state/build-output still throw with Windows separators (gate not weakened). 20/20 pass, tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS application archive validation to consistently handle both Windows- and POSIX-style paths.
  * Continued blocking unexpected application roots, nested app bundles, private state, and build output files from packaged archives.

* **Tests**
  * Added coverage for cross-platform path separators and invalid archive contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->