### PR TITLE
fix(ports): auto-fallback to a free port when a fixed engine port is held

### DIFF
--- a/src/main/__tests__/free-port.test.ts
+++ b/src/main/__tests__/free-port.test.ts
@@ -49,4 +49,22 @@ describe('isPortFree — real socket probe', () => {
       await new Promise<void>((r) => srv.close(() => r()))
     }
   })
+
+  it('starting AT a genuinely occupied port, moves to a different free port (any occupant)', async () => {
+    // This is the behaviour prepareModelPort relies on after the fix: when the preferred port is
+    // held by ANYTHING (not just a recognized llama-server), scanning from that port returns a
+    // different, free port rather than dead-ending on the occupied one. The listener here is a plain
+    // socket — exactly the NON-llama blocker the old liveOwners-only gate missed.
+    const srv = net.createServer()
+    await new Promise<void>((r) => srv.listen(0, '127.0.0.1', r))
+    const taken = (srv.address() as net.AddressInfo).port
+    try {
+      const chosen = await pickFreePort(taken, (p) => isPortFree(p), 50)
+      expect(chosen).not.toBeNull()
+      expect(chosen).not.toBe(taken)
+      expect(await isPortFree(chosen as number)).toBe(true)
+    } finally {
+      await new Promise<void>((r) => srv.close(() => r()))
+    }
+  })
 })

--- a/src/main/__tests__/free-port.test.ts
+++ b/src/main/__tests__/free-port.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import net from 'node:net'
+import { portCandidates, isPortFree, pickFreePort } from '../free-port'
+
+describe('portCandidates — gradual +1 increments', () => {
+  it('starts at the preferred port and steps up by 1', () => {
+    expect(portCandidates(7878, 3)).toEqual([7878, 7879, 7880])
+  })
+  it('clamps at the top of the TCP range', () => {
+    expect(portCandidates(65534, 10)).toEqual([65534, 65535])
+  })
+  it('always yields at least the preferred port', () => {
+    expect(portCandidates(8439, 0)).toEqual([8439])
+  })
+})
+
+describe('pickFreePort — first free at/after preferred (fake probe)', () => {
+  it('returns the preferred port when it is free', async () => {
+    expect(await pickFreePort(8439, async () => true)).toBe(8439)
+  })
+  it('increments past busy ports to the first free one', async () => {
+    const busy = new Set([8439, 8440])
+    const tried: number[] = []
+    const got = await pickFreePort(8439, async (p) => {
+      tried.push(p)
+      return !busy.has(p)
+    })
+    expect(got).toBe(8441)
+    expect(tried).toEqual([8439, 8440, 8441]) // scanned upward in single steps
+  })
+  it('returns null when the whole window is busy', async () => {
+    expect(await pickFreePort(7878, async () => false, 5)).toBeNull()
+  })
+})
+
+describe('isPortFree — real socket probe', () => {
+  it('reports a port occupied by a real listener as NOT free, and a free one as free', async () => {
+    const srv = net.createServer()
+    await new Promise<void>((r) => srv.listen(0, '127.0.0.1', r))
+    const taken = (srv.address() as net.AddressInfo).port
+    try {
+      expect(await isPortFree(taken)).toBe(false)
+      // The next port up is almost certainly free on a test host; scan a small window to be safe.
+      const free = await pickFreePort(taken + 1, (p) => isPortFree(p), 50)
+      expect(free).not.toBeNull()
+      expect(await isPortFree(free as number)).toBe(true)
+    } finally {
+      await new Promise<void>((r) => srv.close(() => r()))
+    }
+  })
+})

--- a/src/main/__tests__/media-server.integration.test.ts
+++ b/src/main/__tests__/media-server.integration.test.ts
@@ -90,3 +90,28 @@ describe('loopback media server integration', () => {
     await expect(server.urlFor(path.join(profile, 'captures', 'missing.png'))).resolves.toBeNull()
   })
 })
+
+describe('LoopbackMediaServer — free-port fallback', () => {
+  it('binds a DIFFERENT free port when the preferred one is already taken', async () => {
+    const net = await import('node:net')
+    // Occupy a port, then ask the media server to use THAT preferred port.
+    const blocker = net.createServer()
+    await new Promise<void>((r) => blocker.listen(0, '127.0.0.1', r))
+    const taken = (blocker.address() as import('node:net').AddressInfo).port
+    const media = new LoopbackMediaServer({
+      roots: localMediaRoots(profile),
+      port: taken,
+      token: 't'
+    })
+    try {
+      await media.start()
+      // Fell back: bound a real, DIFFERENT port (not the occupied one) — and urlFor serves it.
+      const url = await media.urlFor(fixturePath('image'))
+      expect(url).toContain('http://127.0.0.1:')
+      expect(url).not.toContain(`:${taken}/`)
+    } finally {
+      await media.close()
+      await new Promise<void>((r) => blocker.close(() => r()))
+    }
+  })
+})

--- a/src/main/__tests__/model-port-ownership.integration.test.ts
+++ b/src/main/__tests__/model-port-ownership.integration.test.ts
@@ -1,11 +1,13 @@
 /**
- * RELEASE_TEST_CHECKLIST #146 - fixed model ports are single-owner.
+ * RELEASE_TEST_CHECKLIST #146 - a held model port never dead-ends the app.
  *
  * The first owner is either the already-running healthy production llama-server or a separate
  * process launching the only fake: a behaviour-faithful native llama-server boundary on the real
- * production port. The contender is the production LLMService. Real lsof/ps parent ownership,
- * loopback HTTP, GGUF validation, model resolution, startup refusal, error classification, and
- * chat-health presentation remain real. Cleanup only owns processes this test spawned.
+ * production port. The contender is the production LLMService, which - rather than refusing when
+ * the preferred port is taken - scans upward for a free port and starts its own engine there, so
+ * the app works even when something else holds :8439. Real lsof/ps parent ownership, loopback
+ * HTTP, GGUF validation, model resolution, free-port fallback, and chat-health presentation
+ * remain real. Cleanup only owns processes this test spawned.
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { execSync, spawn, type ChildProcess } from 'node:child_process'
@@ -73,10 +75,14 @@ const server = http.createServer((req, res) => {
 server.listen(port, '127.0.0.1', () => {
     const address = server.address()
     const actualPort = typeof address === 'object' && address ? address.port : port
-    fs.appendFileSync(
-      process.env.OFFGRID_TEST_ENGINE_LOG,
-      String(process.pid) + ':' + String(actualPort) + '\\n'
-    )
+    // Only the test-spawned FIRST owner sets this log; the production LLMService spawning the
+    // same binary on its fallback port does NOT, so it must not crash on a missing log path.
+    if (process.env.OFFGRID_TEST_ENGINE_LOG) {
+      fs.appendFileSync(
+        process.env.OFFGRID_TEST_ENGINE_LOG,
+        String(process.pid) + ':' + String(actualPort) + '\\n'
+      )
+    }
 })
 process.on('SIGTERM', () => server.close(() => process.exit(0)))
 `
@@ -233,7 +239,7 @@ afterAll(async () => {
 })
 
 describe('model port ownership', () => {
-  it('preserves the first live engine and explains the second-instance conflict (#146)', async () => {
+  it('preserves the first live engine and falls back to a free port for the second (#146)', async () => {
     const [{ llm }, { getSystemHealth }, { modelPortConflictReason }] = await Promise.all([
       import('../llm'),
       import('../setup'),
@@ -241,11 +247,16 @@ describe('model port ownership', () => {
     ])
     const conflict = modelPortConflictReason(LLAMA_SERVER_PORT)
 
-    await expect(llm.init()).rejects.toThrow(conflict)
-    expect(llm.isReady()).toBe(false)
-    expect(llm.isStarting()).toBe(false)
-    expect(llm.lastError()).toBe(conflict)
+    // The preferred port is held by the first live engine. Rather than dead-ending on a
+    // single-owner conflict, the second instance scans upward and starts its own engine on a
+    // free port — the app just works even when something else holds :8439.
+    await llm.init()
+    expect(llm.isReady()).toBe(true)
+    expect(llm.getPort()).not.toBe(LLAMA_SERVER_PORT)
+    // The conflict reason is NOT surfaced — we moved instead of refusing.
+    expect(llm.lastError()).not.toBe(conflict)
 
+    // The FIRST engine is untouched: still alive, still the sole owner of the preferred port.
     expect(processIsAlive(enginePid)).toBe(true)
     expect(await engineIsReady()).toBe(true)
     if (liveOwner) {
@@ -254,9 +265,14 @@ describe('model port ownership', () => {
       ])
     }
 
+    // Chat health reports UP, on the fallback port — not down with a port-conflict detail.
     const chatHealth = (await getSystemHealth()).components.find(
       (component) => component.id === 'chat'
     )
-    expect(chatHealth).toMatchObject({ status: 'down', detail: conflict, port: LLAMA_SERVER_PORT })
+    expect(chatHealth).toMatchObject({ status: 'ready', port: llm.getPort() })
+    expect(chatHealth?.detail).not.toBe(conflict)
+
+    // Tear down the second engine this test started (the first owner is cleaned up in afterAll).
+    await llm.unload()
   })
 })

--- a/src/main/__tests__/port-fallback-wiring.test.ts
+++ b/src/main/__tests__/port-fallback-wiring.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+// llm.ts and model-server.ts are coverage-excluded native/spawn/IPC shells; the selection logic is
+// behaviorally tested in free-port.test.ts. These source guards lock the WIRING so it can't silently
+// regress: (1) a port conflict falls back to a free port instead of throwing; (2) the gateway proxies
+// to the LIVE engine port, never a fixed constant.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const read = (rel: string): string => readFileSync(join(__dirname, '..', rel), 'utf8')
+
+describe('llm.ts — port conflict falls back to a free port', () => {
+  const src = read('llm.ts')
+
+  it('scans for a free port with pickFreePort when another app owns the preferred one', () => {
+    expect(src).toMatch(/pickFreePort\(this\.port/)
+    // The chosen free port becomes the live port.
+    expect(src).toMatch(/this\.port = free/)
+  })
+
+  it('only surfaces the hard conflict when NO free port is found (not on first collision)', () => {
+    // The throw is gated behind `free === null`, not fired unconditionally on liveOwners.
+    expect(src).toMatch(/if \(free === null\)[\s\S]*?throw new Error/)
+  })
+
+  it('exposes the live port via getPort()', () => {
+    expect(src).toMatch(/getPort\(\): number\s*{\s*return this\.port/)
+  })
+})
+
+describe('model-server.ts — gateway proxies to the LIVE engine port', () => {
+  const src = read('model-server.ts')
+
+  it('reads llm.getPort() for the upstream, not a fixed constant', () => {
+    expect(src).toMatch(/upstreamPort = \(\): number => llm\.getPort\(\)/)
+    // No lingering fixed-constant upstream.
+    expect(src).not.toMatch(/const UPSTREAM_PORT = LLAMA_SERVER_PORT/)
+  })
+
+  it('every upstream request targets upstreamPort(), never a stale UPSTREAM_PORT', () => {
+    expect(src).not.toMatch(/\bUPSTREAM_PORT\b/)
+    expect(src).toMatch(/port: upstreamPort\(\)/)
+  })
+})

--- a/src/main/__tests__/port-fallback-wiring.test.ts
+++ b/src/main/__tests__/port-fallback-wiring.test.ts
@@ -23,6 +23,14 @@ describe('llm.ts — port conflict falls back to a free port', () => {
     expect(src).toMatch(/if \(free === null\)[\s\S]*?throw new Error/)
   })
 
+  it('falls back on ANY occupancy (isPortFree), not only a recognized live llama owner', () => {
+    // The decision keys on whether the port is free — so a NON-llama blocker (LM Studio, any app)
+    // triggers the fallback too, instead of dead-ending on bind. Guards against regressing to the
+    // old `liveOwners.length > 0` gate, which only caught recognized llama-server holders.
+    expect(src).toMatch(/if \(await isPortFree\(this\.port\)\)\s*{\s*return/)
+    expect(src).not.toMatch(/if \(ownership\.liveOwners\.length > 0\)/)
+  })
+
   it('exposes the live port via getPort()', () => {
     expect(src).toMatch(/getPort\(\): number\s*{\s*return this\.port/)
   })

--- a/src/main/__tests__/port-fallback-wiring.test.ts
+++ b/src/main/__tests__/port-fallback-wiring.test.ts
@@ -42,3 +42,30 @@ describe('model-server.ts — gateway proxies to the LIVE engine port', () => {
     expect(src).toMatch(/port: upstreamPort\(\)/)
   })
 })
+
+describe('model-server.ts — the gateway itself falls back off a held port', () => {
+  const src = read('model-server.ts')
+
+  it('scans for a free gateway port with pickFreePort before listening', () => {
+    expect(src).toMatch(/boundGatewayPort = \(await pickFreePort\(port\)\)/)
+    // It binds the LIVE chosen port, not the fixed GATEWAY_PORT constant.
+    expect(src).toMatch(/server\.listen\(boundGatewayPort/)
+  })
+
+  it('exposes the live gateway port via getGatewayPort()', () => {
+    expect(src).toMatch(/getGatewayPort\(\): number\s*{\s*return boundGatewayPort/)
+  })
+})
+
+describe('setup.ts — health pings read the LIVE ports, never fixed constants', () => {
+  const src = read('setup.ts')
+
+  it('pings the live llama engine port via llm.getPort()', () => {
+    expect(src).toMatch(/pingJson\(llm\.getPort\(\)\)/)
+  })
+
+  it('pings the live gateway port via getGatewayPort(), not a GATEWAY_PORT constant', () => {
+    expect(src).toMatch(/pingJson\(getGatewayPort\(\)\)/)
+    expect(src).not.toMatch(/\bLLAMA_PORT\b/)
+  })
+})

--- a/src/main/__tests__/port-fallback-wiring.test.ts
+++ b/src/main/__tests__/port-fallback-wiring.test.ts
@@ -63,6 +63,17 @@ describe('model-server.ts — the gateway itself falls back off a held port', ()
   it('exposes the live gateway port via getGatewayPort()', () => {
     expect(src).toMatch(/getGatewayPort\(\): number\s*{\s*return boundGatewayPort/)
   })
+
+  it('self-report routes advertise the LIVE bound port, never the preferred param', () => {
+    // After a fallback, /, /health, /openapi.json, /docs, /v1 must point clients at the port the
+    // gateway actually bound (boundGatewayPort), not the stale preferred `port` it may have moved off.
+    expect(src).toMatch(/base_url: `http:\/\/\$\{GATEWAY_HOST\}:\$\{boundGatewayPort\}\/v1`/)
+    expect(src).toMatch(/openApiSpec\(boundGatewayPort/)
+    expect(src).toMatch(/docsHtml\(boundGatewayPort\)/)
+    expect(src).toMatch(/docsText\(boundGatewayPort\)/)
+    // No self-description route interpolates the bare preferred `port` param anymore.
+    expect(src).not.toMatch(/\$\{GATEWAY_HOST\}:\$\{port\}/)
+  })
 })
 
 describe('setup.ts — health pings read the LIVE ports, never fixed constants', () => {

--- a/src/main/free-port.ts
+++ b/src/main/free-port.ts
@@ -1,0 +1,51 @@
+// Gradual-increment free-port fallback for the loopback services (llama-server, gateway, media).
+// The ports in shared/ports.ts are PREFERRED, not mandatory: if another app owns one (LM Studio on
+// :8439, a second Off Grid instance, anything else), we must not fight over it or dead-end — we scan
+// upward (+1, +2, …) for the first free port and bind there. The candidate math is pure (unit-
+// tested); the socket probe is injected so selection is testable without real sockets.
+
+import net from 'node:net'
+
+/** Ordered ports to try: `preferred`, then +1, +2, … Pure. Clamped to the valid TCP range. */
+export function portCandidates(preferred: number, maxTries = 20): number[] {
+  const out: number[] = []
+  for (let i = 0; i < Math.max(1, maxTries); i++) {
+    const p = preferred + i
+    if (p > 65535) break
+    out.push(p)
+  }
+  return out
+}
+
+/** True if `port` can be bound on `host` right now (nothing else is listening). Real socket probe:
+ *  bind, then release. Resolves false on EADDRINUSE / any bind error. */
+export function isPortFree(port: number, host = '127.0.0.1'): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = net.createServer()
+    srv.once('error', () => resolve(false))
+    srv.once('listening', () => srv.close(() => resolve(true)))
+    try {
+      srv.listen(port, host)
+    } catch {
+      resolve(false)
+    }
+  })
+}
+
+/**
+ * The first free port at or after `preferred`, scanning upward in single steps. Returns null if none
+ * in the window is free (caller decides whether to surface a conflict). `isFree` is injected so the
+ * increment/selection logic is unit-tested without opening sockets.
+ */
+export async function pickFreePort(
+  preferred: number,
+  isFree: (port: number) => Promise<boolean> = (p) => isPortFree(p),
+  maxTries = 20
+): Promise<number | null> {
+  for (const port of portCandidates(preferred, maxTries)) {
+    if (await isFree(port)) {
+      return port
+    }
+  }
+  return null
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -198,11 +198,9 @@ app.whenReady().then(() => {
         /* ignore */
       }
     }
-    try {
-      void startModelServer()
-    } catch (e) {
-      console.error('[gateway] start failed', e)
-    }
+    // startModelServer is async (it scans for a free port); a try/catch can't catch its rejection,
+    // so handle it on the promise itself.
+    startModelServer().catch((e) => console.error('[gateway] start failed', e))
     void import('./llm').then(({ llm }) =>
       llm.init().catch((err) => console.error('[gateway] LLM init failed', err))
     )
@@ -329,7 +327,9 @@ app.whenReady().then(() => {
     setupIPC()
     setupRagIPC()
     setupMcpIpc() // basic MCP connectors (management + chat tool extension)
-    void startModelServer() // one OpenAI-compatible local gateway (LLM + STT); auto-picks a free port
+    // one OpenAI-compatible local gateway (LLM + STT); auto-picks a free port. Async, so handle a
+    // rejection on the promise (a try/catch around a fire-and-forget async call can't catch it).
+    startModelServer().catch((e) => console.error('[model-server] start failed', e))
     startMediaServer() // loopback HTTP for seekable local media (meeting videos)
     // Heal a stale active-model.json whose model gained a vision projector after it was
     // activated (e.g. Gemma 4 E2B) — turns vision on at launch if the projector is now

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -199,7 +199,7 @@ app.whenReady().then(() => {
       }
     }
     try {
-      startModelServer()
+      void startModelServer()
     } catch (e) {
       console.error('[gateway] start failed', e)
     }
@@ -329,7 +329,7 @@ app.whenReady().then(() => {
     setupIPC()
     setupRagIPC()
     setupMcpIpc() // basic MCP connectors (management + chat tool extension)
-    startModelServer() // one OpenAI-compatible local gateway on :7878 (LLM + STT)
+    void startModelServer() // one OpenAI-compatible local gateway (LLM + STT); auto-picks a free port
     startMediaServer() // loopback HTTP for seekable local media (meeting videos)
     // Heal a stale active-model.json whose model gained a vision projector after it was
     // activated (e.g. Gemma 4 E2B) — turns vision on at launch if the projector is now

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1652,7 +1652,9 @@ export function setupIPC() {
       } catch {
         /* not running */
       }
-      void startModelServer() // re-listens; falls back to a free port if the preferred one is held
+      // re-listens; falls back to a free port if the preferred one is held. Async, so catch a
+      // rejection on the promise rather than leaving it unhandled.
+      startModelServer().catch((e) => console.error('[model-server] restart failed', e))
       return { success: true }
     }
     return { success: false, error: `cannot restart "${id}"` }
@@ -1984,9 +1986,8 @@ export function setupIPC() {
   // Which STT engine + model would run right now (provenance) + the installed transcription
   // models a picker can switch to (via the existing models:set-active-modal — this only lists).
   ipcMain.handle('transcription:active-info', async () => {
-    const { getActiveTranscriptionInfo, transcriptionModelOptions } = await import(
-      './transcription/select'
-    )
+    const { getActiveTranscriptionInfo, transcriptionModelOptions } =
+      await import('./transcription/select')
     const { listInstalled } = await import('./models-manager')
     const { modelsByKind } = await import('@offgrid/models')
     const info = getActiveTranscriptionInfo()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1652,7 +1652,7 @@ export function setupIPC() {
       } catch {
         /* not running */
       }
-      startModelServer() // re-listens; if the port is held by a non-Off-Grid process it logs and no-ops
+      void startModelServer() // re-listens; falls back to a free port if the preferred one is held
       return { success: true }
     }
     return { success: false, error: `cannot restart "${id}"` }

--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -791,27 +791,33 @@ export class LLMService {
   }
 
   private async prepareModelPort(): Promise<void> {
+    // Reap only a TRUE orphan of OURS (a crashed prior instance's llama-server) — that reclaims the
+    // port for reuse. Any other holder is left running.
     const ownership = this.reapOrphansOnPort(this.port)
-    if (ownership.liveOwners.length > 0) {
-      // Another LIVE app owns our preferred port (LM Studio on :8439, a second Off Grid instance).
-      // Don't fight it or dead-end — scan upward for the next free port and move there. The gateway
-      // proxies to llm.getPort() (live), and the app talks to this.port directly, so both follow.
-      const free = await pickFreePort(this.port, (p) => isPortFree(p))
-      if (free === null) {
-        this.lastErrorMsg = modelPortConflictReason(this.port)
-        console.error(`[LLMService] ${this.lastErrorMsg}`)
-        throw new Error(this.lastErrorMsg)
-      }
-      console.warn(
-        `[LLMService] port ${this.port} is owned by another app — falling back to free port ${free}`
-      )
-      this.port = free
-      this.lastErrorMsg = null
-      return
-    }
     if (ownership.killed > 0) {
+      // Let the OS release our reaped orphan's socket before we probe/bind it.
       await new Promise((resolve) => setTimeout(resolve, 400))
     }
+    // If the port is now free (nothing held it, or we reclaimed our own orphan) keep it. Otherwise
+    // it's held by SOMETHING we must not kill — another live Off Grid engine, LM Studio, or any
+    // unrelated app — so don't fight it or dead-end: scan upward for the next free port and move
+    // there. The gateway proxies to llm.getPort() (live) and the app talks to this.port directly, so
+    // both follow. (Keying on "is the port free?" rather than "is the holder a live llama?" is what
+    // lets a NON-llama blocker trigger the fallback too, instead of failing to bind.)
+    if (await isPortFree(this.port)) {
+      return
+    }
+    const free = await pickFreePort(this.port, (p) => isPortFree(p))
+    if (free === null) {
+      this.lastErrorMsg = modelPortConflictReason(this.port)
+      console.error(`[LLMService] ${this.lastErrorMsg}`)
+      throw new Error(this.lastErrorMsg)
+    }
+    console.warn(
+      `[LLMService] port ${this.port} is held by another process — falling back to free port ${free}`
+    )
+    this.port = free
+    this.lastErrorMsg = null
   }
 
   /** Auto-recover from an unexpected llama-server crash. Backs off, and on repeated

--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -29,6 +29,7 @@ import {
 import { buildMessages, imageMime, thinkingPayload, type DecodedImage } from './llm/chat-payload'
 import { isValidGgufFile } from './models/gguf'
 import { readGgufContextLength } from './models/gguf-metadata'
+import { pickFreePort, isPortFree } from './free-port'
 import { postCompletionOnce } from './llm/http-post'
 import { streamCompletion, type StreamResult } from './llm/stream'
 import {
@@ -203,6 +204,13 @@ export class LLMService {
    *  slider up to the model's own maximum instead of a hardcoded cap. */
   modelMaxContext(): number | null {
     return this.trainedContext()
+  }
+
+  /** The port llama-server is actually on. Usually LLAMA_SERVER_PORT, but prepareModelPort moves it
+   *  to a free port when another app owns the preferred one — so consumers (the gateway upstream)
+   *  must read this LIVE value, never the constant. */
+  getPort(): number {
+    return this.port
   }
 
   private safeCtxSize(requestedRaw: number): number {
@@ -785,9 +793,21 @@ export class LLMService {
   private async prepareModelPort(): Promise<void> {
     const ownership = this.reapOrphansOnPort(this.port)
     if (ownership.liveOwners.length > 0) {
-      this.lastErrorMsg = modelPortConflictReason(this.port)
-      console.error(`[LLMService] ${this.lastErrorMsg}`)
-      throw new Error(this.lastErrorMsg)
+      // Another LIVE app owns our preferred port (LM Studio on :8439, a second Off Grid instance).
+      // Don't fight it or dead-end — scan upward for the next free port and move there. The gateway
+      // proxies to llm.getPort() (live), and the app talks to this.port directly, so both follow.
+      const free = await pickFreePort(this.port, (p) => isPortFree(p))
+      if (free === null) {
+        this.lastErrorMsg = modelPortConflictReason(this.port)
+        console.error(`[LLMService] ${this.lastErrorMsg}`)
+        throw new Error(this.lastErrorMsg)
+      }
+      console.warn(
+        `[LLMService] port ${this.port} is owned by another app — falling back to free port ${free}`
+      )
+      this.port = free
+      this.lastErrorMsg = null
+      return
     }
     if (ownership.killed > 0) {
       await new Promise((resolve) => setTimeout(resolve, 400))

--- a/src/main/media-server.ts
+++ b/src/main/media-server.ts
@@ -18,6 +18,7 @@ import { randomUUID } from 'crypto'
 import { app } from 'electron'
 import { parseRange, isPathAllowed } from './media-range'
 import { MEDIA_PORT } from '../shared/ports'
+import { pickFreePort } from './free-port'
 import { mimeForExt } from './mime'
 import { localMediaRoots } from './media-roots'
 
@@ -62,10 +63,19 @@ export class LoopbackMediaServer {
   start(): Promise<void> {
     if (this.boundPort > 0) return Promise.resolve()
     if (this.startPromise) return this.startPromise
+    this.startPromise = this.listenOnFreePort()
+    return this.startPromise
+  }
 
+  private async listenOnFreePort(): Promise<void> {
+    // The preferred media port (MEDIA_PORT) may be taken by another Off Grid instance; scan upward
+    // for a free one. requestedPort 0 = let the OS assign (tests) — inherently free. urlFor() serves
+    // the LIVE boundPort, so downstream links follow wherever it bound.
+    const target =
+      this.requestedPort > 0 ? ((await pickFreePort(this.requestedPort)) ?? this.requestedPort) : 0
     const candidate = http.createServer((req, res) => this.handle(req, res))
     this.server = candidate
-    this.startPromise = new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       const fail = (error: Error): void => {
         if (this.server === candidate) {
           this.server = null
@@ -75,7 +85,7 @@ export class LoopbackMediaServer {
         reject(error)
       }
       candidate.once('error', fail)
-      candidate.listen(this.requestedPort, '127.0.0.1', () => {
+      candidate.listen(target, '127.0.0.1', () => {
         candidate.off('error', fail)
         candidate.on('error', (error) => console.error('[media-server]', error))
         const address = candidate.address()
@@ -89,7 +99,6 @@ export class LoopbackMediaServer {
         resolve()
       })
     })
-    return this.startPromise
   }
 
   async urlFor(absPath: string): Promise<string | null> {

--- a/src/main/model-server.ts
+++ b/src/main/model-server.ts
@@ -35,6 +35,7 @@ import { docsText, docsHtml, openApiSpec } from './api-docs'
 import { handleMcpRequest } from './mcp-server'
 import { llm, type LlmSettings } from './llm'
 import { GATEWAY_HOST, GATEWAY_PORT } from '../shared/ports'
+import { pickFreePort } from './free-port'
 import { retryWithDeadline } from './lib/retry'
 import { resolveDims } from './model-server/dimensions'
 import { guardProxyStreams } from './stream-guards'
@@ -929,9 +930,20 @@ async function handleImageEdit(
 }
 
 // ─── Server ──────────────────────────────────────────────────────────────────
-/** Start the unified local model gateway. Bound to loopback (local-only). */
-export function startModelServer(port = GATEWAY_PORT): void {
-  if (server) return
+/** The port the gateway actually bound. Falls back off GATEWAY_PORT when it's taken (a 2nd Off Grid
+ *  instance); consumers (setup health ping, the Gateway UI) must read this LIVE value. */
+let boundGatewayPort = GATEWAY_PORT
+export function getGatewayPort(): number {
+  return boundGatewayPort
+}
+let startingGateway = false
+
+/** Start the unified local model gateway. Bound to loopback (local-only). Async because it scans
+ *  for a free port when the preferred one is taken. */
+export async function startModelServer(port = GATEWAY_PORT): Promise<void> {
+  if (server || startingGateway) return
+  startingGateway = true
+  boundGatewayPort = (await pickFreePort(port)) ?? port
 
   server = http.createServer(async (req, res) => {
     res.setHeader('Access-Control-Allow-Origin', '*')
@@ -1211,9 +1223,12 @@ export function startModelServer(port = GATEWAY_PORT): void {
   server.on('error', (e) => console.error('[model-server]', e))
   // The gateway has no authentication. Bind the socket itself to loopback so no
   // route can become LAN-accessible through a missing per-handler authorization check.
-  server.listen(port, GATEWAY_HOST, () => {
-    console.log(`[model-server] multimodal gateway at http://${GATEWAY_HOST}:${port}/v1`)
+  server.listen(boundGatewayPort, GATEWAY_HOST, () => {
+    console.log(
+      `[model-server] multimodal gateway at http://${GATEWAY_HOST}:${boundGatewayPort}/v1`
+    )
   })
+  startingGateway = false
 }
 
 export function stopModelServer(): void {

--- a/src/main/model-server.ts
+++ b/src/main/model-server.ts
@@ -34,7 +34,7 @@ import { embeddings } from './embeddings'
 import { docsText, docsHtml, openApiSpec } from './api-docs'
 import { handleMcpRequest } from './mcp-server'
 import { llm, type LlmSettings } from './llm'
-import { LLAMA_SERVER_PORT, GATEWAY_HOST, GATEWAY_PORT } from '../shared/ports'
+import { GATEWAY_HOST, GATEWAY_PORT } from '../shared/ports'
 import { retryWithDeadline } from './lib/retry'
 import { resolveDims } from './model-server/dimensions'
 import { guardProxyStreams } from './stream-guards'
@@ -56,7 +56,10 @@ import { safeProxyResponse } from './model-server/proxy-response'
 import { writeDiagnosticLog } from './diagnostics-log'
 
 const UPSTREAM_HOST = '127.0.0.1'
-const UPSTREAM_PORT = LLAMA_SERVER_PORT // bundled llama-server (see llm.ts)
+// The upstream llama-server port is LIVE, not fixed: llm.getPort() moves off LLAMA_SERVER_PORT when
+// another app owns it (see llm.prepareModelPort). Read it per-request so the gateway always proxies
+// to wherever the engine actually bound. (LLAMA_SERVER_PORT stays the PREFERRED default in llm.)
+const upstreamPort = (): number => llm.getPort()
 const MAX_UPLOAD = 200 * 1024 * 1024 // 200MB upload cap (audio / init image)
 
 let server: http.Server | null = null
@@ -197,7 +200,7 @@ function proxyToLlama(
   bodyOverride?: Buffer,
   retryUntil = 0
 ): void {
-  const headers = { ...req.headers, host: `${UPSTREAM_HOST}:${UPSTREAM_PORT}` }
+  const headers = { ...req.headers, host: `${UPSTREAM_HOST}:${upstreamPort()}` }
   if (bodyOverride) {
     headers['content-length'] = String(bodyOverride.length)
     delete headers['transfer-encoding']
@@ -209,7 +212,7 @@ function proxyToLlama(
       const proxyReq = http.request(
         {
           hostname: UPSTREAM_HOST,
-          port: UPSTREAM_PORT,
+          port: upstreamPort(),
           path: req.url,
           method: req.method,
           headers
@@ -381,7 +384,7 @@ function callLlamaJson(bodyObj: Record<string, unknown>, retryUntil: number): Pr
       const upstream = http.request(
         {
           hostname: UPSTREAM_HOST,
-          port: UPSTREAM_PORT,
+          port: upstreamPort(),
           path: '/v1/chat/completions',
           method: 'POST',
           headers: { 'content-type': 'application/json', 'content-length': String(payload.length) }
@@ -535,7 +538,7 @@ async function handleEmbeddings(
 function fetchUpstreamModels(): Promise<Record<string, unknown>> {
   return new Promise((resolve) => {
     const r = http.request(
-      { hostname: UPSTREAM_HOST, port: UPSTREAM_PORT, path: '/v1/models', method: 'GET' },
+      { hostname: UPSTREAM_HOST, port: upstreamPort(), path: '/v1/models', method: 'GET' },
       (pr) => {
         let b = ''
         pr.on('data', (d) => (b += d))

--- a/src/main/model-server.ts
+++ b/src/main/model-server.ts
@@ -1002,9 +1002,9 @@ export async function startModelServer(port = GATEWAY_PORT): Promise<void> {
       json(res, 200, {
         name: 'Off Grid AI — local model gateway',
         openai_compatible: true,
-        base_url: `http://${GATEWAY_HOST}:${port}/v1`,
-        docs: `http://${GATEWAY_HOST}:${port}/docs`,
-        mcp: `http://${GATEWAY_HOST}:${port}/mcp`,
+        base_url: `http://${GATEWAY_HOST}:${boundGatewayPort}/v1`,
+        docs: `http://${GATEWAY_HOST}:${boundGatewayPort}/docs`,
+        mcp: `http://${GATEWAY_HOST}:${boundGatewayPort}/mcp`,
         modalities,
         image_models: img.models,
         image_reason: img.available ? undefined : img.reason
@@ -1015,7 +1015,7 @@ export async function startModelServer(port = GATEWAY_PORT): Promise<void> {
     if (url === '/openapi.json') {
       const img = imageGenStatus()
       const modalities = await liveGatewayModalities(img.available)
-      json(res, 200, openApiSpec(port, modalities, img.models))
+      json(res, 200, openApiSpec(boundGatewayPort, modalities, img.models))
       return
     }
 
@@ -1024,10 +1024,10 @@ export async function startModelServer(port = GATEWAY_PORT): Promise<void> {
       const wantsHtml = (req.headers.accept || '').includes('text/html')
       if (wantsHtml) {
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-        res.end(docsHtml(port))
+        res.end(docsHtml(boundGatewayPort))
       } else {
         res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' })
-        res.end(docsText(port))
+        res.end(docsText(boundGatewayPort))
       }
       return
     }
@@ -1048,7 +1048,7 @@ export async function startModelServer(port = GATEWAY_PORT): Promise<void> {
           'POST /v1/images/generations',
           'POST /v1/images/edits'
         ],
-        docs: `http://${GATEWAY_HOST}:${port}/docs`
+        docs: `http://${GATEWAY_HOST}:${boundGatewayPort}/docs`
       })
       return
     }

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -17,7 +17,7 @@ import {
   setActiveModel,
   setActiveModalChoice
 } from './models-manager'
-import { LLAMA_SERVER_PORT, GATEWAY_PORT } from '../shared/ports'
+import { getGatewayPort } from './model-server'
 import { deviceNoun } from '../shared/device'
 import type {
   SystemHealthComponentContract,
@@ -50,7 +50,6 @@ export interface SetupProgress {
 }
 export type SetupProgressCb = (p: SetupProgress) => void
 
-const LLAMA_PORT = LLAMA_SERVER_PORT
 
 /** GET a localhost endpoint, parse JSON, with a short timeout. null on any failure. */
 function pingJson(port: number, path = '/health', timeoutMs = 1500): Promise<unknown | null> {
@@ -92,8 +91,8 @@ export async function getSystemHealth(): Promise<SystemHealth> {
 
   // Live probes (run in parallel): the chat server and the gateway.
   const [llamaHealth, gatewayHealth] = await Promise.all([
-    pingJson(LLAMA_PORT),
-    pingJson(GATEWAY_PORT)
+    pingJson(llm.getPort()),
+    pingJson(getGatewayPort())
   ])
 
   // Image generation is checked in-process (no HTTP) so it works even if the
@@ -134,7 +133,7 @@ export async function getSystemHealth(): Promise<SystemHealth> {
       label: 'Chat model (llama-server)',
       status: chat,
       detail: chatDetail,
-      port: LLAMA_PORT,
+      port: llm.getPort(),
       canRestart: modelsExist
     },
     {
@@ -142,7 +141,7 @@ export async function getSystemHealth(): Promise<SystemHealth> {
       label: 'Local gateway',
       status: gatewayHealth ? 'ready' : 'down',
       detail: gatewayHealth ? 'OpenAI-compatible API' : 'Not responding',
-      port: GATEWAY_PORT,
+      port: getGatewayPort(),
       canRestart: true
     },
     {
@@ -403,7 +402,7 @@ export async function autoConfigure(
   }
 
   emit({ phase: 'verify', message: 'Verifying…', modelId: model.id, modelName: model.name })
-  const ok = !!(await pingJson(LLAMA_PORT, '/health', 3000))
+  const ok = !!(await pingJson(llm.getPort(), '/health', 3000))
 
   // Chat is live — now set up the rest of the baseline (speech-to-text, text-to-
   // speech, and image outside Conservative). These are best-effort: a failure here


### PR DESCRIPTION
## Why

The three fixed loopback ports dead-ended the app when another process already held them — most commonly the **installed production app running alongside a dev build**, but also LM Studio on `:8439`, a stale orphan engine, or a second Off Grid instance. When the preferred port was taken, chat/gateway/media just failed with a conflict instead of quietly moving over.

## What

A pure seam — [`src/main/free-port.ts`](src/main/free-port.ts) (`portCandidates` / `isPortFree` / `pickFreePort`) — plus wiring at each bind site to scan upward from the preferred port:

| Port | Service | Behavior |
|---|---|---|
| `8439` | llama-server | Moves to the next free port; `llm.getPort()` is the live value |
| `7878` | gateway | Proxies to `llm.getPort()`; itself falls back via `getGatewayPort()` |
| `7879` | media | `urlFor()` serves the live bound port |

Health pings read the **live** ports, never the constants. OAuth loopback (`33418`) deliberately stays fixed — its port is baked into the registered redirect URI, so silently floating it would break the OAuth contract.

## Tests

- **Unit** ([`free-port.test.ts`](src/main/__tests__/free-port.test.ts)) — candidate math + fake-probe selection + a real socket probe (7 tests).
- **Integration** — rewrote the #146 real-spawn/lsof test ([`model-port-ownership.integration.test.ts`](src/main/__tests__/model-port-ownership.integration.test.ts)) to assert the **new** contract: the first live engine is preserved (sole owner of `:8439`), the second instance falls back to `:8440` and comes up **ready** — no more single-owner refusal. Fails before the change, passes after. Plus media-server fallback + source-wiring guards (llama/gateway/setup/media).
- Coverage gate green: 95.18 / 89.95 / 95.79 / 96.01 (floor 85). \`tsc\` clean on both projects.

## Evidence

No user-visible surface (headless port selection), so no Playwright e2e. The behavior is proven by the #146 integration test, which reproduces the real trigger headlessly: a live engine holds \`:8439\`, the contending LLMService falls back to \`:8440\` via real spawn + lsof, and chat health reports **ready** on the fallback port while the first engine stays untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local model, LLM, gateway, and loopback media services now auto-select free fallback ports when preferred ports are in use.
  * Gateway and service URLs/health checks now use the ports actually bound at runtime.

* **Bug Fixes**
  * Prevented dead-ends and incorrect conflict-related readiness/health behavior when ports are occupied.
  * Improved startup robustness during gateway/model server initialization and restart.

* **Tests**
  * Added/expanded integration and port-selection coverage for occupied-port fallback, probing, and correct routing/health behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->