### PR TITLE
ci(release): beta build is manual-only (no auto-run on merge to main)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,11 @@
 name: Build and Release
 
 on:
-  # Every merge to main publishes to the BETA (nightly) channel — opt-in users only.
-  push:
-    branches:
-      - main
-  # Promote to STABLE on demand: Actions → Build and Release → Run workflow → stable.
-  # (Default beta, so an accidental run never ships stable to everyone.)
+  # MANUAL ONLY. A merge to main no longer auto-builds — we trigger releases on demand so a
+  # merge never spends a build or moves the beta feed on its own. Run it from
+  # Actions → Build and Release → Run workflow, and pick the channel:
+  #   beta   = nightly opt-in feed (default; an accidental run can never ship stable to everyone)
+  #   stable = everyone
   workflow_dispatch:
     inputs:
       channel:
@@ -36,7 +35,8 @@ jobs:
   # throwaway -beta.<run> version WITHOUT committing, so nightly builds never move
   # main's base version or spam it with bump commits.
   version:
-    if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]')
+    # Manual-only trigger, so this always runs on dispatch; the old push/[skip ci] guard is gone.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.bump.outputs.version }}


### PR DESCRIPTION
## Why

A merge to main should not auto-spend a build or move the beta/nightly feed on its own — we trigger releases deliberately.

## What

`.github/workflows/release.yml`:
- **Removed** the `push: branches: [main]` trigger.
- **Kept** `workflow_dispatch` — run from **Actions → Build and Release → Run workflow**, choosing the channel (`beta` default = nightly opt-in feed; `stable` = everyone).
- Simplified the `version` job's `if` (the old push/`[skip ci]` guard is gone; it only runs on dispatch now).

## Verify
- YAML validated: the sole trigger is now `workflow_dispatch`; `version.if` = `github.event_name == 'workflow_dispatch'`.
- Manual runs (beta + stable) are unchanged and still available from the Actions tab.

> Note: worth landing before the Task 1 merge so that merge doesn't auto-fire a beta build.