### PR TITLE
feat(pro): Replay — live on Windows

### DIFF
--- a/src/renderer/src/components/pro/proCatalog.ts
+++ b/src/renderer/src/components/pro/proCatalog.ts
@@ -90,7 +90,12 @@ export const PRO_FEATURES: ProFeature[] = [
       'Jump straight to the moment',
       'Stays on your machine'
     ],
-    platforms: ['darwin']
+    // Ported to Windows: the capture pipeline is vision-model-first, so the macOS OCR
+    // binary is no longer on the path. Screenshots come from Electron desktopCapturer
+    // and the frame store, replay reader and screen carry no platform-native code.
+    // Accessibility text is macOS-only enrichment that never gates analysis, so on
+    // Windows a vision model is what produces frame summaries.
+    platforms: ['darwin', 'win32']
   },
   {
     route: 'meetings',

--- a/src/renderer/src/lib/__tests__/proCatalog.lookup.test.ts
+++ b/src/renderer/src/lib/__tests__/proCatalog.lookup.test.ts
@@ -76,10 +76,25 @@ describe('featureSupportsPlatform (per-feature seam)', () => {
     expect(featureSupportsPlatform(winPorted('x'), 'linux')).toBe(false)
   })
 
-  it('every shipped feature is still macOS-only today (nothing ported yet)', () => {
+  // Ported-to-Windows features, by route. Grows one entry per shipped Windows port;
+  // asserted against the catalog so a flipped `platforms` and this list can't drift.
+  const WIN_PORTED = new Set(['replay'])
+
+  it('replay is live on Windows (vision-first capture, no macOS OCR on the path)', () => {
+    expect(featureSupportsPlatform(getProFeature('replay')!, 'win32')).toBe(true)
+  })
+
+  it('exactly the ported features are win32-supported; the rest stay macOS-only', () => {
     for (const f of PRO_FEATURES) {
-      expect(featureSupportsPlatform(f, 'win32'), `win32 support for ${f.route}`).toBe(false)
+      expect(featureSupportsPlatform(f, 'win32'), `win32 support for ${f.route}`).toBe(
+        WIN_PORTED.has(f.route)
+      )
     }
+  })
+
+  it('a Windows port does not imply Linux (each platform is explicit)', () => {
+    // Guards against a lazy `['darwin', ...allNonMac]` — replay is win32 only, not linux.
+    expect(featureSupportsPlatform(getProFeature('replay')!, 'linux')).toBe(false)
   })
 })
 
@@ -109,12 +124,20 @@ describe('proComingSoonHere', () => {
 })
 
 describe('proFeatureComingSoon', () => {
-  it('gates every Pro route for a Windows Pro subscriber', () => {
+  it('does NOT gate a Windows-ported route — replay renders live on win32', () => {
+    expect(proFeatureComingSoon('replay', 'win32', true)).toBe(false)
+    // still live on macOS, and still upsell (not coming-soon) for free users.
+    expect(proFeatureComingSoon('replay', 'darwin', true)).toBe(false)
+    expect(proFeatureComingSoon('replay', 'win32', false)).toBe(false)
+  })
+
+  it('gates every NOT-yet-ported catalog route for a Windows Pro subscriber', () => {
     for (const feature of PRO_FEATURES) {
+      const ported = featureSupportsPlatform(feature, 'win32')
       expect(
         proFeatureComingSoon(feature.route, 'win32', true),
         `coming-soon for ${feature.route}`
-      ).toBe(true)
+      ).toBe(!ported)
     }
   })
 


### PR DESCRIPTION
Stacks on #49 (capability seam). Pairs with **desktop-pro #30** — both should land together.

## Why this is one line

The plan priced Replay **L**, on the assumption it was blocked on building a Windows OCR provider. That blocker no longer exists. `main` moved the capture pipeline to **vision-model-first**: `pro/main/crm/extract.ts` sends the screenshot to the local vision model and records frames as `source: 'vision'`, and `pro/main/ax-text.ts:52` bails off darwin with the comment that "an unsupported platform must never prevent screenshot analysis." Core `src/main/vision.ts` is pure Electron `desktopCapturer`.

An audit of the entire Replay + capture path found **exactly one** platform reference in it — `capture-opt-in.ts`, the deliberate "start paused on Windows" default — and no osascript, Swift helper or `pgrep` anywhere. `main/crm/replay.ts`, `ReplayScreen.tsx` and the frame store carry no platform-native code.

So the core change is the capability flag and nothing else.

## What's here

- `proCatalog.ts`: `replay` → `platforms: ['darwin', 'win32']`. Verified sufficient — `App.tsx:999` already routes the screen gate through `proFeatureComingSoon`, and nav lock is entitlement-only (`locked: !isPro`), so this one edit lights up nav, gating and upsell copy together.
- Tests: replay live on win32 (not coming-soon), the "exactly the ported features are win32-supported" invariant tracks the flip so gate and catalog can't drift, and a guard that a Windows port does not imply Linux.

**Copy needed no change** — the replay entry was already `deviceNoun`-neutral ("on-device", "Stays on your machine"), with no Mac/Cmd strings.

## The actual engineering is in the pro PR

desktop-pro #30 closes two real Windows gaps in `capture-policy.ts`, which is the privacy half of this port:

1. **The app would capture itself.** `get-windows` reports the exe's FileDescription and falls back to the *filename*, so our own window can arrive as `off-grid-ai.exe`. The self check compared the raw, case-sensitive name, so that form slipped through.
2. **Windows credential surfaces were capturable** — UAC prompts, the lock screen, the Windows Hello dialog, Windows Security had no equivalent of the macOS `SecurityAgent`/`loginwindow` exclusions.

## Deliberately out of scope

`App.tsx:231`'s landing default is still `isPro && isMac() ? 'day' : 'models'`. It yields the correct result today because Day isn't ported, but it is a platform decision living outside the seam and must move behind `featureSupportsPlatform` when Day lands.

## Verification

- `npm test` — **3106 passed**, 4 skipped
- `npm run typecheck` — clean (both projects)
- `eslint` — clean on touched files
- Coverage gate passed on push: statements 95.21%, branches 89.97%, functions 95.85%, lines 96.03%

## Evidence — not yet complete

No Windows screenshots or video yet: this needs the Windows test seat, and per repo rules I won't embed a screenshot I haven't verified shows what it claims. **Not ready to merge until that lands.** What to check on Windows:

- install a vision model (Qwen3-VL 2B), opt in to capture on the Replay screen, confirm frames accumulate and summaries appear
- **confirm Off Grid does not capture itself** — no Off Grid windows in the timeline, no self-derived entities
- confirm a UAC prompt / lock screen is not captured
- report the `[extract]` log's app name for our own window, to confirm which identity form Windows reports
- measure per-frame vision latency — the open throughput question for Replay on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pWGpffyCb7MBDdVPMbEiA