### PR TITLE
feat(pro): Reflect live on Windows

### DIFF
--- a/src/renderer/src/components/pro/proCatalog.ts
+++ b/src/renderer/src/components/pro/proCatalog.ts
@@ -76,7 +76,11 @@ export const PRO_FEATURES: ProFeature[] = [
       'Focus vs. distraction trends',
       'All computed locally — never uploaded'
     ],
-    platforms: ['darwin']
+    // Ported to Windows: Reflect adds no capture of its own — it is pure aggregation
+    // over observations the capture pipeline already writes, which Replay's port put
+    // on Windows. The whole path (crm/reflect.ts, its IPC, ReflectScreen) carries no
+    // platform-native code and reaches SQLite through the same getDB core uses.
+    platforms: ['darwin', 'win32']
   },
   {
     route: 'replay',

--- a/src/renderer/src/lib/__tests__/proCatalog.lookup.test.ts
+++ b/src/renderer/src/lib/__tests__/proCatalog.lookup.test.ts
@@ -38,7 +38,7 @@ const winPorted = (route: string): ProFeature => ({
 // asserted against the catalog so a flipped `platforms` and this list can't drift.
 // Module-scoped because both the featureSupportsPlatform and proFeatureComingSoon
 // describes read it — the gate and the capability check must agree on one list.
-const WIN_PORTED = new Set(['vault', 'clipboard', 'replay'])
+const WIN_PORTED = new Set(['vault', 'clipboard', 'replay', 'reflect'])
 
 describe('getProFeature', () => {
   it('returns the matching feature for a known route', () => {


### PR DESCRIPTION
Fourth Pro feature ported to Windows, after Vault, Clipboard and Replay. The cheapest one yet: **no pro-side change at all**, just the gate flip.

## Why Reflect needs no Windows implementation

Reflect adds no capture of its own — it is pure aggregation over observations the capture pipeline already writes. Replay's port put those observations on Windows, so Reflect had nothing left to port.

A sweep for `osascript|process.platform|darwin|win32|pgrep|pkill|execFile|spawn` over `pro/main/crm/reflect.ts` and `pro/renderer/screens/ReflectScreen.tsx` returns **zero hits**:

- `reflect.ts` (232 lines) imports only core `getDB`, `./schema`, `./utils` — pure SQLite aggregation.
- Its IPC (`crm:day-reflection`, `crm:week-reflection` in `crm-ipc.ts`) is platform-free.
- The only native dep on the path is `better-sqlite3`, already proven on Windows by core.
- Catalog copy and `ReflectScreen.tsx` contain no `Mac` / `macOS` / `Cmd` / `Option` strings, so no copy neutralization was needed.

## Why one catalog edit is sufficient

Same verification that held for Replay:

- Nav lock is entitlement-only — `App.tsx:656`, `locked: !isPro`.
- The screen gate routes through `proFeatureComingSoon` — `App.tsx:999`.
- No core file special-cases the `reflect` route (only the `ViewMode` union, the route map, and the generic `proItem('reflect')`).

So flipping `platforms` lights up nav, gating and copy together from the one source of truth.

## Tests

`WIN_PORTED` in `proCatalog.lookup.test.ts` is parameterized, so adding `reflect` derives four assertions rather than hand-written ones:

- `reflect is live on Windows`
- `reflect is win32-only, not linux by implication`
- the `exactly the ported features are win32-supported` invariant
- `does NOT gate reflect — it renders live on win32`

Reflect's own logic keeps its existing real-DB integration coverage (`pro/main/crm/__tests__/reflect.integration.test.ts`, 13 cases), unchanged and green.

```
Test Files  377 passed | 2 skipped (379)
     Tests  3161 passed | 4 skipped (3165)
```

Typechecks clean on all three configs (node, web, pro). ESLint clean on both touched files.

## Evidence note

**No screenshot is possible from this seat, and there is no macOS-visible change to capture.** On darwin, `featureSupportsPlatform` already returned true for `reflect` before this change, so behaviour on a Mac is bit-identical. The only visible change is on Windows, where the Reflect tab stops showing "coming soon" and renders the real screen — which is exactly what needs verifying on the Windows test seat.

Per the working agreement, this PR stays open until Anurag confirms on real Windows hardware.

**Windows verification asked for:**
- With capture running and observations accumulating, confirm mind-share / category / app breakdowns populate and the day view is non-empty.
- Confirm the 7-day week rollup aggregates.
- Report whether Windows app identities read sensibly in the app breakdown. They come from `get-windows`, which reports the exe FileDescription and can fall back to the filename — the same identity quirk Replay's self-capture fix dealt with. A wall of `chrome.exe`-style names would be the tell.

## Test-failure accounting (corrected)

**Correction to an earlier version of this PR body.** It claimed three e2e specs failed and that all three "fail identically on `main`". That claim was wrong and is withdrawn. `npx playwright test` does **not** rebuild — `test:e2e` is `electron-vite build && playwright test` — so both the failing run and the baseline run were executed against a **stale bundle**, and the comparison proved nothing.

The accurate picture, after a proper rebuild, on a real display with `pro/` present:

```
72 passed | 2 failed | 6 skipped
```

- `chat-memory.spec.ts:141` and `meeting-transcription.spec.ts:46` — **never actually failed.** Stale-build artifacts.
- `settings-sections.spec.ts:124` "resource mode survives a relaunch" — a **real core bug**, unrelated to Reflect: `LLMService` resolved its settings path in the constructor, before `app.setPath('userData', …)`, so an `OFFGRID_USER_DATA` profile was ignored. Root-caused with a probe and fixed in **#73**. With that fix the spec file is 3/3.
- `smoke.spec.ts:68` — flake under full-suite parallel load; passes twice in isolation.

Neither remaining failure is caused by this change, which adds no logic — a comment and one entry in a platform list.

Unit suite on this branch:

```
Test Files  377 passed | 2 skipped (379)
     Tests  3161 passed | 4 skipped (3165)
```

One flake seen along the way (`PermissionGate.capture-vision.integration.test.tsx`, a `waitFor` timeout under parallel load) — passes in isolation and in full runs.

**Coverage gate:** the pre-push floor is calibrated core-only; with `pro/` present its Electron-shell files enter the denominator and drag branches below the floor. Pre-existing calibration gap, not a regression from this change. Pushed using the documented workaround of moving `pro/` aside so the gate measured its calibration basis, then restoring it. No `--no-verify`.

**On the e2e gate itself:** CI's e2e job is advisory (`continue-on-error: true`, `ci.yml:158`), so the green check on this PR coexists with 13 failing specs in the CI run. Most are the headless-runner instability the job comment documents; one was the real bug now fixed in #73.
## Not in scope

`App.tsx:231`'s landing default is still `isPro && isMac() ? 'day' : 'models'` — a platform decision living outside the seam. Harmless for Reflect (never the landing default) and correct today, but it must move behind `featureSupportsPlatform` before **Day** lands, or a ported Day will be stranded on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U3TnnNULxfCb4TsjAGjiC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reflect Pro is now supported on Windows, in addition to macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
