### PR TITLE
fix(release): the release build gets the shared monorepo it depends on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,45 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      # `@offgrid/sync` is a file: dependency on the shared monorepo, so it must sit BESIDE this
+      # checkout before `npm ci` runs - an install cannot resolve a path that does not exist, and the
+      # typecheck inside `npm run build` then fails on every import of it. `ci.yml` has done this since
+      # the sync work landed; this workflow did not, which is why no release has built since 2026-07-30.
+      #
+      # The release ref decides the shared ref: a release from `main` takes shared `main`, and a release
+      # from an integration branch takes the branch of the same name when one exists.
+      - name: Checkout shared at the matching ref
+        id: shared_branch
+        continue-on-error: true
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: off-grid-ai/shared
+          token: ${{ secrets.CI_CROSS_REPO_TOKEN }}
+          ref: ${{ github.ref_name }}
+          path: _shared
+          persist-credentials: false
+      - name: Fall back to shared main
+        if: ${{ steps.shared_branch.outcome != 'success' }}
+        continue-on-error: true
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: off-grid-ai/shared
+          token: ${{ secrets.CI_CROSS_REPO_TOKEN }}
+          path: _shared
+          persist-credentials: false
+      - name: Put shared beside this checkout
+        run: |
+          if [ ! -d _shared ]; then
+            echo "::error::off-grid-ai/shared was not checked out - @offgrid/sync cannot resolve. Check CI_CROSS_REPO_TOKEN."
+            exit 1
+          fi
+          rm -rf ../shared
+          mv _shared ../shared
+          # Install at the WORKSPACE ROOT: shared is an npm-workspaces monorepo whose lockfile and
+          # build tool live at the root, and packages/sync declares neither. A locked install, so a
+          # drifted lock stops the release instead of resolving a graph nobody committed.
+          npm --prefix ../shared ci
+          npm --prefix ../shared/packages/sync run build
       - name: Install dependencies
         run: npm ci
       # Stamp the resolved version into package.json so electron-builder picks the
@@ -387,6 +426,45 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      # `@offgrid/sync` is a file: dependency on the shared monorepo, so it must sit BESIDE this
+      # checkout before `npm ci` runs - an install cannot resolve a path that does not exist, and the
+      # typecheck inside `npm run build` then fails on every import of it. `ci.yml` has done this since
+      # the sync work landed; this workflow did not, which is why no release has built since 2026-07-30.
+      #
+      # The release ref decides the shared ref: a release from `main` takes shared `main`, and a release
+      # from an integration branch takes the branch of the same name when one exists.
+      - name: Checkout shared at the matching ref
+        id: shared_branch
+        continue-on-error: true
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: off-grid-ai/shared
+          token: ${{ secrets.CI_CROSS_REPO_TOKEN }}
+          ref: ${{ github.ref_name }}
+          path: _shared
+          persist-credentials: false
+      - name: Fall back to shared main
+        if: ${{ steps.shared_branch.outcome != 'success' }}
+        continue-on-error: true
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: off-grid-ai/shared
+          token: ${{ secrets.CI_CROSS_REPO_TOKEN }}
+          path: _shared
+          persist-credentials: false
+      - name: Put shared beside this checkout
+        run: |
+          if [ ! -d _shared ]; then
+            echo "::error::off-grid-ai/shared was not checked out - @offgrid/sync cannot resolve. Check CI_CROSS_REPO_TOKEN."
+            exit 1
+          fi
+          rm -rf ../shared
+          mv _shared ../shared
+          # Install at the WORKSPACE ROOT: shared is an npm-workspaces monorepo whose lockfile and
+          # build tool live at the root, and packages/sync declares neither. A locked install, so a
+          # drifted lock stops the release instead of resolving a graph nobody committed.
+          npm --prefix ../shared ci
+          npm --prefix ../shared/packages/sync run build
       - name: Install dependencies
         run: npm ci
       - name: Fetch Windows native binaries (llama/whisper/sd/ffmpeg)


### PR DESCRIPTION
`@offgrid/sync` is a `file:../shared` dependency, so it has to sit beside the checkout before `npm ci` runs. An install cannot resolve a path that is not there, and the typecheck inside `npm run build` then fails on every import of it.

That is how tonight's beta died — [run 31502834587](https://github.com/off-grid-ai/OGAD/actions/runs/31502834587), build-mac, ~40 `TS2307` lines naming one missing module.

`ci.yml` has staged shared since the sync work landed; this workflow never did, which is why no release has built since 2026-07-30. Both `build-mac` and `build-win` now check out shared at the release's own ref, fall back to shared `main`, install at the workspace root and build `packages/sync` — the same sequence `ci.yml` uses.

Workflow-only change. No source touched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR stages and builds the adjacent shared monorepo before installing the application dependencies in both release jobs.
- Checks out a matching shared ref with a fallback to shared main.
- Installs the shared workspace and builds `packages/sync`.
- The Windows copy of the setup script lacks the Bash shell declaration required by its POSIX commands.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the Windows shared-workspace step explicitly uses Bash or is rewritten in PowerShell, because every Windows release build currently aborts there.

The macOS setup follows a compatible shell path, but the identical POSIX script is executed by default PowerShell on windows-2022, preventing the Windows release job from reaching dependency installation or artifact generation.

**Files Needing Attention:** .github/workflows/release.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds shared-monorepo staging to both release jobs, but the Windows staging script uses Bash syntax under the default PowerShell shell. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Manual release dispatch] --> B[Build macOS]
  B --> C[Checkout matching shared ref]
  C -->|Failure| D[Fallback to shared main]
  C -->|Success| E[Move shared beside checkout]
  D --> E
  E --> F[Install and build shared sync package]
  F --> G[Build application]
  G --> H[Build Windows]
  H --> I[Run shared setup with default PowerShell]
  I --> J[Bash syntax rejected]
  J --> K[Windows artifacts not produced]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): the release build gets the..."](https://github.com/off-grid-ai/ogad/commit/e77873629c264984c4b0e3e3af28c8a675bc7d19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52298836)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS and Windows release build preparation.
  * Release builds now verify required shared components are available and built before packaging.
  * Added clearer failure handling when required build resources cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->