### PR TITLE
feat(gateway): image generation offload - job-service routing, sync_id, poll progress, per-device auth

### DIFF
--- a/src/main/__tests__/image-route-auth.integration.test.ts
+++ b/src/main/__tests__/image-route-auth.integration.test.ts
@@ -1,0 +1,83 @@
+// The gateway's image routes against the REAL server: opportunistic auth
+// (no credentials = today's open posture; presented credentials are verified
+// against the live per-device tokens), and the unavailable-runtime 501.
+import net from 'node:net'
+import type { AddressInfo } from 'node:net'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { startModelServer, stopModelServer } from '../model-server'
+import { registerActiveActionTokens } from '../mcp-auth'
+
+let port = 0
+const DEVICE_TOKEN = 'f'.repeat(64)
+
+async function freeLoopbackPort(): Promise<number> {
+  const probe = net.createServer()
+  await new Promise<void>((resolve, reject) => {
+    probe.once('error', reject)
+    probe.listen(0, '127.0.0.1', resolve)
+  })
+  const found = (probe.address() as AddressInfo).port
+  await new Promise<void>((resolve, reject) => {
+    probe.close((error) => (error ? reject(error) : resolve()))
+  })
+  return found
+}
+
+const postImage = (headers: Record<string, string> = {}): Promise<Response> =>
+  fetch(`http://127.0.0.1:${String(port)}/v1/images/generations`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify({ prompt: 'a lighthouse' })
+  })
+
+beforeAll(async () => {
+  port = await freeLoopbackPort()
+  registerActiveActionTokens(() => [DEVICE_TOKEN])
+  startModelServer(port)
+  const deadline = Date.now() + 2_000
+  for (;;) {
+    try {
+      await fetch(`http://127.0.0.1:${String(port)}/health`)
+      break
+    } catch (error) {
+      if (Date.now() > deadline) throw error
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+})
+
+afterAll(async () => {
+  registerActiveActionTokens(null)
+  await stopModelServer()
+})
+
+describe('gateway image routes', () => {
+  it('without credentials keeps the open posture (reaches the 501, not a 401)', async () => {
+    const res = await postImage()
+    expect(res.status).toBe(501) // no image runtime in the test environment
+  })
+
+  it('a valid per-device token is accepted (past auth, same 501)', async () => {
+    const res = await postImage({ authorization: `Bearer ${DEVICE_TOKEN}` })
+    expect(res.status).toBe(501)
+  })
+
+  it('an invalid presented credential is a hard 401, before any work', async () => {
+    const res = await postImage({ authorization: `Bearer ${'0'.repeat(64)}` })
+    expect(res.status).toBe(401)
+    const body = (await res.json()) as { error: { type: string } }
+    expect(body.error.type).toBe('unauthorized')
+  })
+
+  it('guards the unified /v1/images route the same way', async () => {
+    const res = await fetch(`http://127.0.0.1:${String(port)}/v1/images`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer wrong-token-of-decent-length'
+      },
+      body: JSON.stringify({ prompt: 'x' })
+    })
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/main/model-server.ts
+++ b/src/main/model-server.ts
@@ -30,13 +30,15 @@ import path from 'path'
 import { randomUUID } from 'crypto'
 import { desktopExtraction } from './rag/extractors'
 import * as tts from './tts'
-import { generateImage, imageGenStatus, activeImageModel, type ImageGenParams } from './imagegen'
+import { imageGenStatus, activeImageModel, type ImageGenParams } from './imagegen'
+import { imageGenerationJobs } from './imagegen/job-service'
+import { pollProgress, shapeImageResponse } from './model-server/image-route'
 import { whisperModel } from './rag/extractors'
 import { getActiveModal } from './active-models'
 import { embeddings } from './embeddings'
 import { docsText, docsHtml, openApiSpec } from './api-docs'
 import { handleMcpRequest } from './mcp-server'
-import { logActionTokenForDev } from './mcp-auth'
+import { isActionAuthorized, logActionTokenForDev } from './mcp-auth'
 import { llm, type LlmSettings } from './llm'
 import { GATEWAY_HOST, GATEWAY_BIND_HOST, GATEWAY_PORT } from '../shared/ports'
 import { pickFreePort } from './free-port'
@@ -187,6 +189,8 @@ function handlePoll(res: http.ServerResponse, id: string): void {
   }
   if (r.status === 'completed') body.result = r.result
   if (r.status === 'failed') body.error = r.error
+  const progress = pollProgress(r.kind, r.status, imageGenerationJobs.status())
+  if (progress) body.progress = progress
   json(res, 200, body)
 }
 
@@ -743,22 +747,22 @@ async function executeImage(
       err.status = 501
       throw err
     }
-    const out = await generateImage(params)
-    const b64 = out.dataUrl.slice(out.dataUrl.indexOf(',') + 1)
-    const datum =
-      responseFormat === 'url'
-        ? {
-            url: `file://${out.path}`,
-            revised_prompt: out.prompt,
-            seed: out.seed,
-            model: out.model
-          }
-        : { b64_json: b64, revised_prompt: out.prompt, seed: out.seed, model: out.model }
-    return {
-      created: Math.floor(Date.now() / 1000),
-      data: [datum],
-      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+    // Through the job service, not generateImage() directly - one owner of job
+    // identity for every caller. That restores the single-job admission the
+    // renderer already respects, and gives the image a syncId + sidecar, so it
+    // appears in this Mac's gallery and ships to paired devices over the mesh
+    // exactly like a locally started generation.
+    try {
+      imageGenerationJobs.assertCanStart()
+    } catch (busyError) {
+      const err = new Error(
+        busyError instanceof Error ? busyError.message : String(busyError)
+      ) as Error & { status?: number }
+      err.status = 429
+      throw err
     }
+    const out = await imageGenerationJobs.start(params)
+    return shapeImageResponse(out, responseFormat)
   } finally {
     cleanup?.()
   }
@@ -1150,10 +1154,28 @@ export async function startModelServer(port = GATEWAY_PORT): Promise<void> {
         )
       return
     }
-    if (url === '/v1/images' && method === 'POST') return void handleImagesUnified(req, res, rid)
-    if (url === '/v1/images/generations' && method === 'POST')
+    // Image routes: opportunistic auth. A caller that presents a bearer gets it
+    // verified against the live per-device action tokens (a paired phone sends
+    // its own); presenting an invalid credential is a hard 401. No credentials
+    // keeps the gateway's documented open-LAN posture unchanged.
+    const imageAuthRejected = (): boolean => {
+      if (!req.headers.authorization) return false
+      if (isActionAuthorized(req)) return false
+      json(res, 401, errBody('Invalid bearer token.', 'unauthorized'))
+      return true
+    }
+    if (url === '/v1/images' && method === 'POST') {
+      if (imageAuthRejected()) return
+      return void handleImagesUnified(req, res, rid)
+    }
+    if (url === '/v1/images/generations' && method === 'POST') {
+      if (imageAuthRejected()) return
       return void handleImageGeneration(req, res, rid)
-    if (url === '/v1/images/edits' && method === 'POST') return void handleImageEdit(req, res, rid)
+    }
+    if (url === '/v1/images/edits' && method === 'POST') {
+      if (imageAuthRejected()) return
+      return void handleImageEdit(req, res, rid)
+    }
 
     // --- Model management (pull / delete / activate / list) — the full headless
     // repertoire, so the gateway is self-sufficient without the desktop UI. ---

--- a/src/main/model-server/__tests__/image-route.test.ts
+++ b/src/main/model-server/__tests__/image-route.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { pollProgress, shapeImageResponse } from '../image-route'
+
+const OUT = {
+  dataUrl: 'data:image/png;base64,UE5HQllURVM=',
+  path: '/ud/generated-images/img-1.png',
+  prompt: 'a lighthouse in a storm',
+  seed: 42,
+  model: 'flux-schnell',
+  syncId: 'sync-123'
+}
+
+describe('shapeImageResponse', () => {
+  it('returns b64_json by default, carrying the mesh sync_id for dedupe', () => {
+    const body = shapeImageResponse(OUT, 'b64_json') as {
+      data: [{ b64_json: string; sync_id: string; revised_prompt: string; seed: number }]
+    }
+    expect(body.data[0].b64_json).toBe('UE5HQllURVM=')
+    expect(body.data[0].sync_id).toBe('sync-123')
+    expect(body.data[0].revised_prompt).toBe(OUT.prompt)
+    expect(body.data[0].seed).toBe(42)
+  })
+
+  it('returns a file url when asked, and omits sync_id when the job had none', () => {
+    const { syncId: _unused, ...noSync } = OUT
+    const body = shapeImageResponse(noSync, 'url') as { data: [Record<string, unknown>] }
+    expect(body.data[0].url).toBe(`file://${OUT.path}`)
+    expect('b64_json' in body.data[0]).toBe(false)
+    expect('sync_id' in body.data[0]).toBe(false)
+  })
+})
+
+describe('pollProgress', () => {
+  const running = { phase: 'running', stage: 'generating', progress: { step: 12, total: 30 } } as never
+
+  it('reports stage + step for a running image request', () => {
+    expect(pollProgress('image', 'running', running)).toEqual({
+      stage: 'generating',
+      step: 12,
+      total: 30
+    })
+  })
+
+  it('stays silent for other kinds, other statuses, and an idle job service', () => {
+    expect(pollProgress('chat', 'running', running)).toBeNull()
+    expect(pollProgress('image', 'queued', running)).toBeNull()
+    expect(pollProgress('image', 'completed', running)).toBeNull()
+    expect(
+      pollProgress('image', 'running', { phase: 'idle', stage: null, progress: null } as never)
+    ).toBeNull()
+  })
+
+  it('reports the stage alone while there are no sampler steps yet (enhancing)', () => {
+    expect(
+      pollProgress('image', 'running', {
+        phase: 'running',
+        stage: 'enhancing',
+        progress: null
+      } as never)
+    ).toEqual({ stage: 'enhancing' })
+  })
+})

--- a/src/main/model-server/image-route.ts
+++ b/src/main/model-server/image-route.ts
@@ -1,0 +1,52 @@
+// Pure shaping for the gateway's image routes. No I/O, no Electron - extracted
+// from model-server.ts so the response shape (incl. sync_id), the busy mapping,
+// and the poll progress enrichment are defined once and unit-testable.
+import type { ImageGenerationJobContract } from '../../shared/image-generation-contract'
+
+export interface GatewayImageOutput {
+  dataUrl: string
+  path: string
+  prompt: string
+  seed?: number
+  model?: string
+  /** The image's mesh identity, present when the job service produced it. */
+  syncId?: string
+}
+
+/** OpenAI-shaped image response. `sync_id` names the same image on the device
+ *  mesh, so a paired phone can dedupe the synced copy against this response. */
+export function shapeImageResponse(
+  out: GatewayImageOutput,
+  responseFormat: string
+): Record<string, unknown> {
+  const base = {
+    revised_prompt: out.prompt,
+    seed: out.seed,
+    model: out.model,
+    ...(out.syncId ? { sync_id: out.syncId } : {})
+  }
+  const datum =
+    responseFormat === 'url'
+      ? { url: `file://${out.path}`, ...base }
+      : { b64_json: out.dataUrl.slice(out.dataUrl.indexOf(',') + 1), ...base }
+  return {
+    created: Math.floor(Date.now() / 1000),
+    data: [datum],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+  }
+}
+
+/** Live progress for a pending image poll. Only meaningful while THIS request is
+ *  the running job - the single-job lock guarantees that: a request that reached
+ *  'running' holds the job service, so its snapshot is ours to report. */
+export function pollProgress(
+  kind: string,
+  status: string,
+  job: Pick<ImageGenerationJobContract, 'phase' | 'stage' | 'progress'>
+): Record<string, unknown> | null {
+  if (kind !== 'image' || status !== 'running' || job.phase !== 'running') return null
+  return {
+    stage: job.stage,
+    ...(job.progress ? { step: job.progress.step, total: job.progress.total } : {})
+  }
+}


### PR DESCRIPTION
## What this does

**Review note - merge order:** this branch sits on top of `feat/windows-parity` (it uses its per-device token infrastructure). Merge that to main first; this PR's diff then collapses to the single offload commit (617e982). Mobile half: off-grid-ai/OGAM#638.

The desktop half of phone->Mac image-generation offload: a paired (or any LAN) phone POSTs the gateway's existing `/v1/images/generations` in async mode and receives a desktop-quality image; the mobile half is the matching `feat/image-gen-offload` branch in OGAM.

- **Image routes run through `ImageGenerationJobService`** instead of calling `generateImage()` directly. That restores the single-job admission for gateway callers (second request = 429), and gives every gateway image a syncId + sidecar - so it appears in this Mac's own gallery and ships to paired devices over the existing mesh share, exactly like a locally started generation.
- **Responses carry `sync_id`** so a paired requester dedupes the mesh copy against the HTTP result (the phone uses it as the local file id).
- **Pending polls report live progress** (`{stage, step, total}`) - the phone maps this into its normal generation card.
- **Opportunistic bearer auth on the image routes**: a presented token is verified against the live per-device action tokens from this branch's tool-grant mesh (401 on mismatch); no credentials keeps the gateway's documented open-LAN posture unchanged.

## Verification

Unit + integration: 5 pure tests (`image-route.test.ts`: response shaping, sync_id, poll progress gating) + 4 against the real booted gateway (`image-route-auth.integration.test.ts`: open posture reaches 501, valid token accepted, invalid = 401 on both routes). Full suite green through the pre-push gate.

Verified live on a dev build (2026-08-26): 501 honest reason with no model; SDXL pulled headlessly via `/v1/models/pull`; sync generation returned b64 + sync_id with the sidecar landing in `generated-images/`; async 202 + poll showed `step 3/4 -> 4/4 -> completed` with the result held at the poll URL; concurrent request 429'd; bad bearer 401'd. End-to-end phone->Mac generation confirmed on a real iPhone against this branch (image generated on the Mac, delivered into the phone chat).

No screenshots: the change is headless (HTTP surface); the live curl transcript above is the visual. The user-facing surface ships in the OGAM PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

