### PR TITLE
fix(browser): dock the final page + bind chat-opened browser tabs to their chat

### DIFF
--- a/src/main/browser/browser-host.ts
+++ b/src/main/browser/browser-host.ts
@@ -448,19 +448,27 @@ class BrowserHost implements BrowserRailHost {
     return child
   }
 
-  newTab(): { sessionId: string } {
+  /** A manual tab belongs to the chat that opened it (journeyId), so the docked
+   * pane scopes it to that chat and it does not leak into other conversations.
+   * Tabs opened outside a chat (the Tasks route) stay unbound. */
+  newTab(journeyId?: string): { sessionId: string } {
     const sessionId = randomUUID()
-    const record = this.createSession({ sessionId, historyId: sessionId, kind: 'manual' })
+    const record = this.createSession({
+      sessionId,
+      historyId: sessionId,
+      kind: 'manual',
+      ...(journeyId ? { journeyId } : {})
+    })
     return { sessionId: record.sessionId }
   }
 
   /** Open a Chat link as a normal manual page. This is deliberately separate
    * from runTask: reading a source must never start Web Use automation. */
-  async openUrl(url: string): Promise<{ sessionId: string } | null> {
+  async openUrl(url: string, journeyId?: string): Promise<{ sessionId: string } | null> {
     if (!/^https?:\/\//i.test(url)) return null
     const target = normalizeBrowserAddress(url)
     if (!target) return null
-    const opened = this.newTab()
+    const opened = this.newTab(journeyId)
     await this.navigate(target, opened.sessionId)
     return opened
   }
@@ -1041,9 +1049,13 @@ export function registerBrowserViewIpc(): void {
     if (!isBrowserRegionOwner(owner)) return
     browserHost().setRegion(owner, parseRect(raw))
   })
-  ipcMain.handle('browser:new-tab', () => browserHost().newTab())
-  ipcMain.handle('browser:open-url', (_event, url: unknown) =>
-    typeof url === 'string' ? browserHost().openUrl(url) : null
+  ipcMain.handle('browser:new-tab', (_event, journeyId: unknown) =>
+    browserHost().newTab(typeof journeyId === 'string' ? journeyId : undefined)
+  )
+  ipcMain.handle('browser:open-url', (_event, url: unknown, journeyId: unknown) =>
+    typeof url === 'string'
+      ? browserHost().openUrl(url, typeof journeyId === 'string' ? journeyId : undefined)
+      : null
   )
   ipcMain.handle('browser:get-sessions', () => browserHost().getSessions())
   ipcMain.handle('browser:activate-session', (_event, sessionId: unknown) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -107,9 +107,10 @@ const offGridApi = {
       owner: 'docked' | 'floating',
       rect: { x: number; y: number; width: number; height: number } | null
     ) => ipcRenderer.send('browser:set-region', owner, rect),
-    newTab: (): Promise<{ sessionId: string }> => ipcRenderer.invoke('browser:new-tab'),
-    openUrl: (url: string): Promise<{ sessionId: string } | null> =>
-      ipcRenderer.invoke('browser:open-url', url),
+    newTab: (journeyId?: string): Promise<{ sessionId: string }> =>
+      ipcRenderer.invoke('browser:new-tab', journeyId),
+    openUrl: (url: string, journeyId?: string): Promise<{ sessionId: string } | null> =>
+      ipcRenderer.invoke('browser:open-url', url, journeyId),
     getSessions: (): Promise<BrowserSessionsSnapshot> => ipcRenderer.invoke('browser:get-sessions'),
     activateSession: (sessionId: string): Promise<boolean> =>
       ipcRenderer.invoke('browser:activate-session', sessionId),

--- a/src/renderer/src/components/MemoryChat.tsx
+++ b/src/renderer/src/components/MemoryChat.tsx
@@ -93,6 +93,7 @@ import { Button } from '@renderer/components/ui/button'
 import { ActionGateDock } from '@renderer/components/actions/ActionGateDock'
 import { TaskPanelTrigger } from '@renderer/components/tasks/TaskPanelTrigger'
 import { useTaskWorkspaceOpen } from '@renderer/lib/task-side-panel'
+import { setActiveConversationId as publishActiveConversationId } from '@renderer/lib/active-conversation'
 import { useWorkspacePaneController } from './workspace/useWorkspacePaneController'
 import {
   guidanceTaskForJourney,
@@ -2543,6 +2544,9 @@ export function MemoryChat({
   const [activeConversationId, setActiveConversationId] = useState<string | null>(null)
   useEffect(() => {
     onActiveConversationChange?.(activeConversationId)
+    // Publish to the module store so out-of-tree handlers (Chat link clicks) can
+    // bind opened browser tabs to this chat.
+    publishActiveConversationId(activeConversationId)
   }, [activeConversationId, onActiveConversationChange])
   // Active tab's messages (derived) + a shim so the existing active-conversation call
   // sites keep working. The send path targets its own conv via setConvMessages instead.

--- a/src/renderer/src/components/__tests__/ChatMarkdown.links.integration.test.tsx
+++ b/src/renderer/src/components/__tests__/ChatMarkdown.links.integration.test.tsx
@@ -10,11 +10,13 @@ import {
   onOpenTaskSidePanel,
   type OpenTaskPanelRequest
 } from '@renderer/lib/task-side-panel'
+import { setActiveConversationId } from '@renderer/lib/active-conversation'
 
 describe('ChatMarkdown links', () => {
   beforeEach(() => {
     resetTaskSessionStoreForTests()
     closeTaskWorkspace()
+    setActiveConversationId(null)
   })
 
   afterEach(() => {
@@ -24,13 +26,15 @@ describe('ChatMarkdown links', () => {
     vi.restoreAllMocks()
   })
 
-  it('opens a web link in the Off Grid AI browser and refuses unsafe links', () => {
+  it('opens a web link in the Off Grid AI browser bound to the active chat and refuses unsafe links', () => {
     const openExternal = vi.fn()
     const openUrl = vi.fn(async () => ({ sessionId: 'manual-1' }))
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: { openExternal, browser: { openUrl } }
     })
+    // The page opens into whichever chat the user is in, so the docked pane scopes it there.
+    setActiveConversationId('conv-42')
 
     render(
       <ChatMarkdown content="[Docs](https://example.com/docs) [Unsafe](javascript:alert(1))" />
@@ -39,7 +43,7 @@ describe('ChatMarkdown links', () => {
     fireEvent.click(screen.getByText('Unsafe'))
 
     expect(openUrl).toHaveBeenCalledTimes(1)
-    expect(openUrl).toHaveBeenCalledWith('https://example.com/docs')
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/docs', 'conv-42')
     expect(openExternal).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -183,8 +183,8 @@ interface RendererAPIOverrides {
       owner: 'docked' | 'floating',
       rect: { x: number; y: number; width: number; height: number } | null
     ) => void
-    newTab: () => Promise<{ sessionId: string }>
-    openUrl: (url: string) => Promise<{ sessionId: string } | null>
+    newTab: (journeyId?: string) => Promise<{ sessionId: string }>
+    openUrl: (url: string, journeyId?: string) => Promise<{ sessionId: string } | null>
     getSessions: () => Promise<{
       activeSessionId: string | null
       sessions: Array<{

--- a/src/renderer/src/lib/active-conversation.ts
+++ b/src/renderer/src/lib/active-conversation.ts
@@ -1,0 +1,20 @@
+/**
+ * The chat the user is currently in.
+ *
+ * Exists so surfaces OUTSIDE the chat component tree can bind their work to the
+ * active chat without threading the id through every caller. A Chat link click
+ * (openChatLink) opens a browser tab and needs to tag it with the owning chat so
+ * the docked pane scopes it there - but the link handler lives deep in the
+ * markdown renderer, far from where activeConversationId is held. MemoryChat is
+ * the single writer; readers ask via getActiveConversationId.
+ */
+
+let activeConversationId: string | null = null
+
+export function setActiveConversationId(id: string | null): void {
+  activeConversationId = id
+}
+
+export function getActiveConversationId(): string | null {
+  return activeConversationId
+}

--- a/src/renderer/src/lib/chat-link.ts
+++ b/src/renderer/src/lib/chat-link.ts
@@ -1,6 +1,7 @@
 import { safeChatExternalUrl } from '@offgrid/sync'
 import { openExternal } from '../constants/links'
 import { openTaskSidePanel } from './task-side-panel'
+import { getActiveConversationId } from './active-conversation'
 
 /** Open a link from Chat without turning a read into an automated Web Use task. */
 export function openChatLink(href: string | null | undefined): boolean {
@@ -8,7 +9,9 @@ export function openChatLink(href: string | null | undefined): boolean {
   if (!safeUrl) return false
   if (/^https?:/i.test(safeUrl) && window.api.browser?.openUrl) {
     openTaskSidePanel({ kind: 'web_use' })
-    void window.api.browser.openUrl(safeUrl)
+    // Bind the page to the current chat so it docks here and does not leak into
+    // other conversations (the docked pane scopes manual tabs by journeyId).
+    void window.api.browser.openUrl(safeUrl, getActiveConversationId() ?? undefined)
     return true
   }
   openExternal(safeUrl)


### PR DESCRIPTION
## What

Fixes the in-chat browser (task workspace) so browser tabs belong to the chat that opened them, on the Release 107 head. Core side of the change; pro side is desktop-pro#44 (bumped here via the submodule).

### The bug
Manual browser tabs — **Open final page**, the **+** button, and Chat links — were created global (no chat binding). Once the docked pane surfaced them they appeared in **every** chat, so opening or switching to a new chat re-opened the browser. Earlier in the stack the final page also floated instead of docking, and **+** evicted the final-page tab.

### The fix
- Thread the active chat's id through `newTab`/`openUrl` (main + preload) so a manual session is created with that chat's `journeyId`. The session snapshot already carried `journeyId`.
- Added `active-conversation.ts` — a small SSOT the out-of-tree Chat-link handler reads so it can tag opened pages with the current chat (MemoryChat is the single writer).
- Pro pane (desktop-pro#44) scopes manual tabs to their chat and drops the old "show all live manual tabs" workaround.

Result: a tab opened in chat A docks in chat A and never re-appears in chat B; the final page still docks; **+** no longer evicts.

## Verification
- `npx tsc --noEmit -p tsconfig.node.json` and `-p tsconfig.web.json` clean (web shows only pre-existing `TS6307` config-noise in `pro/**`, none in changed files).
- `(cd pro && npx tsc --noEmit -p tsconfig.json)` clean.
- Unit suite green (5453 pass). Pre-push coverage gate passed (all floors met).
- Added: cross-chat regression test in the pane suite; updated the ChatMarkdown links test to assert the chat id is threaded into `openUrl`.

## Evidence
Scoping/logic fix, covered by the pane + link tests (incl. a new cross-chat guard). Screenshots pending an e2e capture run — can attach before merge if preferred.

## Merge note
Merge **desktop-pro#44 first**, then this (it points the pro submodule at pro `4586dcd`).