### PR TITLE
feat(sync): complete CLIP projector transfer on Desktop

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -34,7 +34,14 @@ while read -r _local_ref local_oid _remote_ref remote_oid; do
   [ "$local_oid" = "$ZERO_OID" ] && continue
   if [ "$remote_oid" = "$ZERO_OID" ]; then
     base=$(git merge-base "$local_oid" origin/main 2>/dev/null || true)
-    [ -n "$base" ] && range="$base..$local_oid" || range="$local_oid^..$local_oid"
+    if [ -n "$base" ]; then
+      range="$base..$local_oid"
+    elif git rev-parse "$local_oid^" >/dev/null 2>&1; then
+      range="$local_oid^..$local_oid"
+    else
+      CHANGED_FILES="$CHANGED_FILES $(git diff-tree --no-commit-id --name-only -r --diff-filter=ACMR "$local_oid")"
+      continue
+    fi
   else
     range="$remote_oid..$local_oid"
   fi

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,10 +1,10 @@
 #!/bin/sh
-# Pre-push product checks and diagnostic coverage report.
+# Pre-push product checks.
 #
 # Bypass in a genuine emergency with:  git push --no-verify
 
-# Local gate mirrors CI's hard gates so a push can't be red on arrival: typecheck (fast
-# fail), then the coverage ratchet. Bypass only in a genuine emergency with --no-verify;
+# Local gate checks types, architecture, and tests related to the pushed files. CI owns the full
+# suite and coverage matrix. Bypass only in a genuine emergency with --no-verify;
 # if a running app is holding a model port (:8439) so a port-owner test can't bind, stop it
 # first rather than bypassing — see CLAUDE.md "model ports are single-owner".
 echo "[pre-push] typecheck — npm run typecheck"
@@ -25,138 +25,40 @@ if ! npm run --silent test:architecture:models; then
   exit 1
 fi
 
-# Coverage is measured across EVERY suite and gated on the code this branch ADDS, not on whole files it
-# happened to touch. Three things were wrong with gating `npm run test:coverage` against vitest.config.ts's
-# Earlier coverage thresholds were removed. Coverage is now report-only.
-#
-#   1. That command runs ONE of three vitest projects, while the 85% floor beside it was calibrated on more -
-#      so a partial measurement was asked to clear a fuller floor, and had been failing on this branch
-#      regardless of what anyone did (82.4% branches vs 85%, verified both with and without recent changes).
-#   2. A file covered by the DB journeys or the e2e tour read as 0% here, because those suites report
-#      separately. src/main/database.ts and friends are excluded BY NAME for that reason - a hand-maintained
-#      list that silently rots.
-#   3. Whole-file denominators mean touching thirty lines of a two-thousand-line file drops 1970 untouched
-#      lines into the number, so no amount of testing the new lines can move it.
-#
-# So: run each suite, keep its report, gate once on the union. The floors are a RATCHET recording what this
-# branch achieves. Raise them as coverage rises; do not lower them to pass.
-echo "[pre-push] coverage 1/3 — UI behavior + service integration"
-FAST_TEST_STATUS=0
-if ! npm run --silent test:coverage; then
-  FAST_TEST_STATUS=1
-  echo ""
-  echo "[pre-push] NOTE: the fast suite reported failures or missed its own thresholds. The aggregate gate"
-  echo "[pre-push] below is the authority - but a failing TEST still blocks, because vitest writes no report"
-  echo "[pre-push] at all when one fails."
-fi
-
-echo "[pre-push] coverage 2/3 — DB journeys (real SQLite)"
-DB_TEST_STATUS=0
-if ! OFFGRID_DB_VITEST_CONFIG=vitest.db.coverage.config.ts npm run --silent test:db -- --coverage; then
-  DB_TEST_STATUS=1
-  echo "[pre-push] NOTE: the DB journeys reported failures; their contribution may be missing below."
-fi
-
-# Full Playwright e2e on the built app — the one gate the unit/integration suite can't give:
-# does the built app actually render + drive its surfaces. Specs needing real models/engine binaries
-# self-skip when absent, so this runs the model-free tour (onboarding, nav, Settings, Models,
-# Replay + capture toggle, Integrations).
-#
-# HEADLESS on macOS: `npm run test:e2e` sets OFFGRID_E2E_HEADLESS=1, so the app never calls show() and
-# stays out of the Dock (src/main/bootstrap/window-presentation.ts). Before that, every push opened ~25
-# maximized windows and took the keyboard away from whoever was working, so the gate was routinely
-# skipped with OFFGRID_SKIP_E2E=1 - quiet bought by not running the tests. Measured: 80 passed headless,
-# and the only specs that fail do so on a real display too. Watch a run with OFFGRID_E2E_HEADED=1.
-#
-# CONDITIONAL: the e2e boots its own app on a fresh profile and the smoke specs assert against the
-# fixed engine ports (:8439 llama, :7878 gateway). If ANOTHER Off Grid AI Desktop app is already running (the
-# installed app, or `npm run dev`), it holds those ports — the e2e app correctly falls back to a
-# free port (that's the whole feature), but the port-pinned smoke specs then hit the wrong instance
-# and false-fail. So skip the e2e gate when the ports are occupied and let CI (clean env) be the
-# authority; run it locally only when nothing else holds them. Bypass entirely with OFFGRID_SKIP_E2E=1.
-port_busy() { lsof -ti tcp:"$1" >/dev/null 2>&1; }
-# OFF BY DEFAULT. The e2e is a 6-minute suite and CI runs it on every PR anyway; running it on every
-# local push made the gate something to be worked around rather than trusted, and it is the single
-# biggest reason pushes here felt hostile. Ask for it explicitly when you want it:
-#   OFFGRID_E2E_ON_PUSH=1 git push        # this push runs the suite (on the box if it answers)
-if [ "${OFFGRID_E2E_ON_PUSH:-0}" != "1" ]; then
-  echo "[pre-push] e2e gate — not run (set OFFGRID_E2E_ON_PUSH=1 to run it here); CI runs it on the PR."
-elif [ "${OFFGRID_SKIP_E2E:-0}" = "1" ]; then
-  echo "[pre-push] e2e gate — skipped (OFFGRID_SKIP_E2E=1); CI still runs it."
-elif port_busy 8439 || port_busy 7878; then
-  echo "[pre-push] e2e gate — SKIPPED: an Off Grid AI Desktop app holds :8439/:7878, so a clean e2e can't run"
-  echo "[pre-push] here (the fresh-profile app would fall back off those ports and the port-pinned"
-  echo "[pre-push] smoke specs would false-fail). CI runs the full e2e in a clean environment."
-else
-  # ADVISORY, not blocking. NOTE: the old reason given here — "some specs need a real model/engine"
-  # — was a misdiagnosis. The specs that were failing had stale selectors, not missing models, and
-  # being advisory hid that for days. What remains is genuinely environment-dependent: the clipboard
-  # quick-open spec drives a real global hotkey (see docs/GAPS_BACKLOG.md) - it fails on a real display
-  # as well as headless, so window visibility is not what it is waiting for. Run it and SURFACE failures
-  # with screenshots without stopping the push; CI runs it too. Graduate to blocking once it is
-  # deterministic.
-  # OFFGRID_E2E_COVERAGE makes this tour COUNT towards the gate below. Without it, everything only the built
-  # app reaches - Electron bootstrap, IPC registration, rendered screens - reads as uncovered.
-  echo "[pre-push] coverage 3/3 + e2e (advisory)"
-  export OFFGRID_E2E_COVERAGE="$PWD/coverage-e2e-raw"
-  rm -rf "$OFFGRID_E2E_COVERAGE" coverage-e2e
-  # The TEST BOX first, whenever it answers. It is a clean machine with nothing else holding the engine
-  # ports, and it keeps ~25 app launches off the developer's screen entirely. Exit 20 means the box was
-  # unavailable rather than the suite failing, so that alone falls back to a local headless run - the
-  # gate must never silently skip because a machine was off.
-  e2e_status=0
-  if bash scripts/e2e-on-box.sh; then
-    e2e_status=0
+# Run only the Vitest projects related to files in this push. CI owns the complete suite and
+# coverage matrix. The local hook stays fast enough that developers can keep it enabled.
+ZERO_OID="0000000000000000000000000000000000000000"
+CHANGED_FILES=""
+while read -r _local_ref local_oid _remote_ref remote_oid; do
+  [ -z "$local_oid" ] && continue
+  [ "$local_oid" = "$ZERO_OID" ] && continue
+  if [ "$remote_oid" = "$ZERO_OID" ]; then
+    base=$(git merge-base "$local_oid" origin/main 2>/dev/null || true)
+    [ -n "$base" ] && range="$base..$local_oid" || range="$local_oid^..$local_oid"
   else
-    e2e_status=$?
-    if [ "$e2e_status" -eq 20 ]; then
-      echo "[pre-push] the test box is unavailable — running the suite here (headless)"
-      npm run --silent test:e2e
-      e2e_status=$?
-    fi
+    range="$remote_oid..$local_oid"
   fi
-  if [ "$e2e_status" -ne 0 ]; then
+  CHANGED_FILES="$CHANGED_FILES $(git diff --name-only --diff-filter=ACMR "$range")"
+done
+
+if [ -z "$CHANGED_FILES" ]; then
+  CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
+fi
+
+RELATED_SOURCES=$(printf '%s\n' $CHANGED_FILES | grep -E '\.(ts|tsx|js|jsx|mjs|cjs)$' || true)
+if [ -z "$RELATED_SOURCES" ]; then
+  echo "[pre-push] related tests - no JavaScript or TypeScript files changed"
+else
+  echo "[pre-push] related Vitest projects"
+  # shellcheck disable=SC2086 -- Vitest expects each changed path as a separate argument.
+  if ! node scripts/vitest-electron-node.mjs related \
+    --project ui-behavior-integration \
+    --project service-integration \
+    --project database-integration \
+    --project database-exclusive-integration \
+    $RELATED_SOURCES; then
     echo ""
-    echo "[pre-push] WARNING: e2e reported failures (see e2e/screenshots + output above). NOT blocking"
-    echo "[pre-push] the push. Do NOT assume it's environmental — check the actual failure. Re-run a"
-    echo "[pre-push] suspect spec with OFFGRID_E2E_HEADED=1 to watch it; if it fails there too, it is a"
-    echo "[pre-push] real break and not the headless run."
-  else
-    echo "[pre-push] e2e passed."
-  fi
-  # c8 turns the raw V8 output into an Istanbul report. Its statement map comes from the bundle, so the gate
-  # takes it as --coarse: covered lines only, never a denominator (it maps whole files, blank lines included).
-  if [ -n "$(ls -A "$OFFGRID_E2E_COVERAGE" 2>/dev/null)" ]; then
-    ../shared/node_modules/.bin/c8 report --temp-directory="$OFFGRID_E2E_COVERAGE" --reporter=json \
-      --report-dir=coverage-e2e --all=false >/dev/null 2>&1 || true
+    echo "[pre-push] BLOCKED: a related behavioral test failed."
+    exit 1
   fi
 fi
-
-# Report the union of the coverage reports. Coverage percentages are diagnostic;
-# behavioral test failures remain blocking.
-MEASURE=../shared/scripts/new-code-coverage.mjs
-REPORTS=""
-[ -f coverage/coverage-final.json ] && REPORTS="$REPORTS coverage/coverage-final.json"
-[ -f coverage-db/coverage-final.json ] && REPORTS="$REPORTS coverage-db/coverage-final.json"
-COARSE=""
-[ -f coverage-e2e/coverage-final.json ] && COARSE="--coarse=coverage-e2e/coverage-final.json"
-
-if [ -z "$REPORTS" ]; then
-  echo "[pre-push] coverage report unavailable."
-else
-  echo "[pre-push] coverage report — new code, across every suite that ran"
-  node "$MEASURE" . $REPORTS $COARSE || true
-fi
-
-if [ "$FAST_TEST_STATUS" -ne 0 ] || [ "$DB_TEST_STATUS" -ne 0 ]; then
-  echo ""
-  echo "[pre-push] BLOCKED: one or more behavioral test suites failed."
-  exit 1
-fi
-echo "[pre-push] behavioral tests passed; coverage report complete."
-
-# The gold-standard hygiene adoption has LANDED on this branch: prettier is applied repo-wide
-# (enforced by eslint's prettier/prettier rule) and the structural rules (curly / complexity /
-# max-lines / max-params / no-shadow …) are a warn ratchet in eslint.config.mjs. No standing
-# TODO here anymore — see CLAUDE.md "Code hygiene (adopted)". Tighten the ratchet to error as
-# the god-files decompose; never loosen it to pass.

--- a/src/main/__tests__/startup-adapter-registration.integration.dbtest.ts
+++ b/src/main/__tests__/startup-adapter-registration.integration.dbtest.ts
@@ -6,6 +6,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import sharp from 'sharp'
 import { afterAll, describe, expect, it, vi } from 'vitest'
 
 const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'offgrid-startup-adapters-'))
@@ -13,6 +14,68 @@ const originalDataDir = process.env.OFFGRID_DATA_DIR
 const originalSkipCompatibleGenerationModel = process.env.OFFGRID_SKIP_COMPATIBLE_GENERATION_MODEL
 process.env.OFFGRID_DATA_DIR = profile
 process.env.OFFGRID_SKIP_COMPATIBLE_GENERATION_MODEL = '1'
+
+const generatedImagesDirectory = path.join(profile, 'generated-images')
+const legacyImagePath = path.join(generatedImagesDirectory, 'legacy-image.png')
+const incompleteImagePath = path.join(generatedImagesDirectory, 'incomplete-image.png')
+const orphanedImagePath = path.join(generatedImagesDirectory, 'orphaned-image.png')
+const orphanedCopyPath = path.join(generatedImagesDirectory, 'orphaned-image-copy.png')
+fs.mkdirSync(generatedImagesDirectory, { recursive: true })
+for (const [index, imagePath] of [
+  legacyImagePath,
+  incompleteImagePath,
+  orphanedImagePath
+].entries()) {
+  await sharp({
+    create: {
+      width: 1,
+      height: 1,
+      channels: 4,
+      background: { r: index, g: 0, b: 0, alpha: 1 }
+    }
+  })
+    .png()
+    .toFile(imagePath)
+}
+fs.writeFileSync(
+  `${legacyImagePath}.json`,
+  JSON.stringify({
+    width: 1,
+    height: 1,
+    metadataJson: JSON.stringify({ modelId: '', prompt: 'Legacy image', seed: 0, steps: 20 })
+  })
+)
+fs.writeFileSync(
+  `${incompleteImagePath}.json`,
+  JSON.stringify({
+    width: 1,
+    height: 1,
+    metadataJson: JSON.stringify({
+      modelId: 'legacy-model',
+      prompt: 'Incomplete',
+      seed: 0,
+      steps: 0
+    })
+  })
+)
+fs.writeFileSync(
+  `${orphanedImagePath}.json`,
+  JSON.stringify({
+    syncId: 'orphaned-image',
+    width: 1,
+    height: 1,
+    conversationId: 'deleted-conversation',
+    messageId: 'deleted-message',
+    metadataJson: JSON.stringify({
+      modelId: 'legacy-model',
+      prompt: 'Orphaned image',
+      seed: 1,
+      steps: 20
+    })
+  })
+)
+fs.copyFileSync(orphanedImagePath, orphanedCopyPath)
+fs.copyFileSync(`${orphanedImagePath}.json`, `${orphanedCopyPath}.json`)
 
 vi.mock('electron', () => ({
   app: {
@@ -67,5 +130,27 @@ describe('Desktop adapters during early-shell startup', () => {
       releaseActions = registerActionsIpc()
       registerTaskHistoryIpc()
     }).not.toThrow()
+  })
+
+  it('starts without degrading when a legacy image has no model identifier', async () => {
+    await composition.startDesktopApplication()
+
+    expect(composition.desktopApplication.generatedImages?.snapshot().images).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          local: expect.objectContaining({ fileName: path.basename(legacyImagePath) }),
+          modelId: 'legacy:unknown'
+        }),
+        expect.objectContaining({
+          id: 'orphaned-image',
+          conversationId: null,
+          modelId: 'legacy-model'
+        })
+      ])
+    )
+    expect(composition.desktopApplication.snapshot().degraded).not.toContainEqual(
+      expect.objectContaining({ source: 'desktop sidecar migration' })
+    )
+    expect(fs.existsSync(incompleteImagePath)).toBe(true)
   })
 })

--- a/src/main/__tests__/startup-adapter-registration.integration.dbtest.ts
+++ b/src/main/__tests__/startup-adapter-registration.integration.dbtest.ts
@@ -1,0 +1,71 @@
+/**
+ * The real Desktop composition root must exist before the early shell binds adapters to it.
+ * The temporary Electron profile is the only boundary replacement; application construction,
+ * facade proxies, and all three startup adapters are production code.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, describe, expect, it, vi } from 'vitest'
+
+const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'offgrid-startup-adapters-'))
+const originalDataDir = process.env.OFFGRID_DATA_DIR
+const originalSkipCompatibleGenerationModel = process.env.OFFGRID_SKIP_COMPATIBLE_GENERATION_MODEL
+process.env.OFFGRID_DATA_DIR = profile
+process.env.OFFGRID_SKIP_COMPATIBLE_GENERATION_MODEL = '1'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => profile,
+    getAppPath: () => process.cwd(),
+    getVersion: () => 'test',
+    isPackaged: false
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString()
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+  ipcMain: {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    handle: vi.fn(),
+    removeHandler: vi.fn()
+  }
+}))
+
+const composition = await import('../composition/application')
+const { desktopApplicationStatus } = await import('../composition/application-access')
+const { setupRagIPC } = await import('../rag-ipc')
+const { registerActionsIpc } = await import('../actions/actions-ipc')
+const { registerTaskHistoryIpc } = await import('../tasks/task-history-ipc')
+const { getDB } = await import('../database')
+
+let releaseRag: (() => void) | null = null
+let releaseActions: (() => void) | null = null
+
+afterAll(async () => {
+  releaseActions?.()
+  releaseRag?.()
+  await composition.stopDesktopApplication()
+  if (getDB().open) getDB().close()
+  if (originalDataDir === undefined) delete process.env.OFFGRID_DATA_DIR
+  else process.env.OFFGRID_DATA_DIR = originalDataDir
+  if (originalSkipCompatibleGenerationModel === undefined)
+    delete process.env.OFFGRID_SKIP_COMPATIBLE_GENERATION_MODEL
+  else process.env.OFFGRID_SKIP_COMPATIBLE_GENERATION_MODEL = originalSkipCompatibleGenerationModel
+  fs.rmSync(profile, { recursive: true, force: true })
+})
+
+describe('Desktop adapters during early-shell startup', () => {
+  it('binds every application-backed adapter before domain startup', () => {
+    expect(desktopApplicationStatus()).toBe('created')
+
+    expect(() => {
+      releaseRag = setupRagIPC()
+      releaseActions = registerActionsIpc()
+      registerTaskHistoryIpc()
+    }).not.toThrow()
+  })
+})

--- a/src/main/__tests__/startup-stages.integration.dbtest.ts
+++ b/src/main/__tests__/startup-stages.integration.dbtest.ts
@@ -97,6 +97,36 @@ describe('Desktop startup stages through real application health', () => {
     expect(changes).toEqual(['active'])
   })
 
+  it('settles when work observer registration fails', async () => {
+    let completeWork!: () => void
+    let stageContext: StartupStageContext | undefined
+    const pendingWork = new Promise<void>((resolve) => {
+      completeWork = resolve
+    })
+
+    const result = await runStartupStage({
+      name: 'desktop.models.observe',
+      deadlineMs: 1_000,
+      required: true,
+      observeWork() {
+        throw new Error('another preparation task is already registered')
+      },
+      async run(context) {
+        stageContext = context
+        return pendingWork
+      }
+    })
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'failed',
+      error: 'another preparation task is already registered'
+    })
+    expect(stageContext?.isOwner()).toBe(false)
+    completeWork()
+    await pendingWork
+  })
+
   it('returns typed failures, reports domain degradation, and collects independent work', async () => {
     const [successful, failed] = await runIndependentStartupStages([
       {

--- a/src/main/application-main.ts
+++ b/src/main/application-main.ts
@@ -18,6 +18,7 @@ import { ipcMain } from 'electron'
 import { loadProEntitlementProvider, loadProFeaturesMain } from './bootstrap/loadProFeaturesMain'
 import { resolveWindowPresentation } from './bootstrap/window-presentation'
 import { mayUseIsolatedEvidenceInstance } from './bootstrap/isolated-evidence-instance'
+import { registerDesktopStartupTextModelPreparation } from './composition/application-access'
 
 /**
  * Whether this launch may put itself on screen or take the keyboard. Resolved ONCE: the main window, the Dock
@@ -43,7 +44,7 @@ const windowPresentation = resolveWindowPresentation(process.env)
  * so.
  */
 function runTextModelPrepareStage(): Promise<StartupStageResult<StartupTextModelState>> {
-  return runStartupStage({
+  const stage = runStartupStage({
     // Heavy, and entirely optional to having a window: chat says so itself when no model is ready.
     name: 'models.text.prepare',
     deadlineMs: 180_000,
@@ -64,6 +65,8 @@ function runTextModelPrepareStage(): Promise<StartupStageResult<StartupTextModel
       return outcome.value
     }
   })
+  registerDesktopStartupTextModelPreparation(stage)
+  return stage
 }
 
 function isServerOnlyLaunch(): boolean {

--- a/src/main/application-main.ts
+++ b/src/main/application-main.ts
@@ -50,6 +50,7 @@ function runTextModelPrepareStage(): Promise<StartupStageResult<StartupTextModel
     deadlineMs: 180_000,
     domain: 'models',
     lateEffectIsRecoverable: true,
+    observeWork: registerDesktopStartupTextModelPreparation,
     run: async ({ operationId }) => {
       // Await the composition root MODULE, and take the facade from it. Not the
       // `application-access` proxy: that throws until the root has been registered, and this stage
@@ -65,7 +66,6 @@ function runTextModelPrepareStage(): Promise<StartupStageResult<StartupTextModel
       return outcome.value
     }
   })
-  registerDesktopStartupTextModelPreparation(stage)
   return stage
 }
 

--- a/src/main/composition/application-access.ts
+++ b/src/main/composition/application-access.ts
@@ -26,6 +26,28 @@ interface DesktopApplicationRegistry {
   current: OffGridApplication | null
 }
 
+let startupTextModelPreparation: Promise<unknown> | null = null
+
+/**
+ * Bind Pro background generation to the one startup text-model preparation already in flight.
+ * This stores the actual stage promise, not a second readiness flag, and releases it when settled.
+ */
+export function registerDesktopStartupTextModelPreparation(task: Promise<unknown>): void {
+  if (startupTextModelPreparation && startupTextModelPreparation !== task) {
+    throw new Error('Desktop startup text-model preparation is already registered.')
+  }
+  startupTextModelPreparation = task
+  const release = (): void => {
+    if (startupTextModelPreparation === task) startupTextModelPreparation = null
+  }
+  void task.then(release, release)
+}
+
+/** Wait only when startup currently owns text-model preparation. */
+export async function awaitDesktopStartupTextModelPreparation(): Promise<void> {
+  await startupTextModelPreparation
+}
+
 const registryHost = globalThis as typeof globalThis & {
   __offgridDesktopApplicationRegistry?: DesktopApplicationRegistry
 }

--- a/src/main/composition/application.ts
+++ b/src/main/composition/application.ts
@@ -154,10 +154,13 @@ if (desktopApplication.generatedImages) {
   )
 }
 
-// Registered for the life of the running application. `startDesktopApplication` re-registers so a
-// stop followed by a start in one process is served, and `stopDesktopApplication` disposes so a late
-// caller after stop gets "not initialized" rather than a stopped instance.
-let releaseApplicationRegistration: (() => void) | null = null
+// The constructed application is the process composition root, so every early IPC adapter can bind
+// to that one identity before its domains start. Runtime state still belongs to Shared: callers see
+// the facade's explicit `created` state until `startDesktopApplication` advances it. Keeping the
+// registration until stop also lets a stopped root become unavailable instead of leaving a stale
+// singleton behind.
+let releaseApplicationRegistration: (() => void) | null =
+  registerDesktopApplication(desktopApplication)
 
 let starting: ReturnType<typeof desktopApplication.start> | null = null
 let releaseSyncRuntime: (() => void) | null = null

--- a/src/main/downloaded-models.ts
+++ b/src/main/downloaded-models.ts
@@ -147,6 +147,10 @@ export function desktopAsyncDownloadedRegistryPorts(dir: string): AsyncDownloade
         throw error
       }
     },
+    containsInstalledFamily: async ({ familyId }) => {
+      const rows = desktopDownloadedRegistryPorts(dir).read()
+      return rows.some(row => row.id === familyId || row.familyId === familyId)
+    },
     packageIdentity: (input) =>
       modelPackageIdentity({
         ...input,

--- a/src/main/imagegen/gallery-migration.ts
+++ b/src/main/imagegen/gallery-migration.ts
@@ -24,7 +24,13 @@ interface MigrationRepository {
 interface LegacyGalleryRecord {
   readonly record: GeneratedImageRecord
   readonly messageId?: string
+  readonly byteIdentity: string
 }
+
+// Old sidecars could retain every generation fact except the model identifier. Preserve those
+// images with an explicit unknown legacy origin instead of inventing a model or blocking the whole
+// gallery migration.
+const LEGACY_UNKNOWN_MODEL_ID = 'legacy:unknown'
 
 async function contentIdentity(imagePath: string): Promise<string> {
   return createHash('sha256')
@@ -43,27 +49,27 @@ function assertLegacyMessageRelation(
   }
 }
 
-async function legacyRecord(imagePath: string): Promise<LegacyGalleryRecord> {
+async function legacyRecord(imagePath: string): Promise<LegacyGalleryRecord | null> {
   const sidecar = readGeneratedImageSidecar(imagePath)
   const generation = readGeneratedImageMetadata(sidecar.metadataJson)
   const image = await sharp(imagePath).metadata()
   const stat = await fs.promises.stat(imagePath)
-  const id = sidecar.syncId ?? (await contentIdentity(imagePath))
+  const byteIdentity = await contentIdentity(imagePath)
+  const id = sidecar.syncId ?? byteIdentity
   const width = sidecar.width ?? image.width
   const height = sidecar.height ?? image.height
   assertLegacyMessageRelation(imagePath, sidecar)
-  if (
-    !generation?.prompt ||
-    !generation.modelId ||
-    !generation.steps ||
-    generation.seed === undefined
-  ) {
-    throw new Error(`Generated image ${path.basename(imagePath)} has incomplete generation facts.`)
+  if (!generation?.prompt || !generation.steps || generation.seed === undefined) {
+    console.warn(
+      `[gallery-migration] preserving ${path.basename(imagePath)} on disk because its legacy generation facts are incomplete`
+    )
+    return null
   }
   if (!width || !height) {
     throw new Error(`Generated image ${path.basename(imagePath)} has no readable dimensions.`)
   }
   return {
+    byteIdentity,
     record: createGeneratedImageRecord({
       id,
       ...(sidecar.conversationId === undefined ? {} : { conversationId: sidecar.conversationId }),
@@ -75,12 +81,49 @@ async function legacyRecord(imagePath: string): Promise<LegacyGalleryRecord> {
       height,
       steps: generation.steps,
       seed: generation.seed,
-      modelId: generation.modelId,
+      modelId: generation.modelId?.trim() || LEGACY_UNKNOWN_MODEL_ID,
       createdAt: sidecar.createdAt ?? stat.mtime.toISOString(),
       local: { path: imagePath, fileName: path.basename(imagePath) }
     }),
     ...(sidecar.messageId ? { messageId: sidecar.messageId } : {})
   }
+}
+
+function sameGeneration(left: LegacyGalleryRecord, right: LegacyGalleryRecord): boolean {
+  return (
+    left.byteIdentity === right.byteIdentity &&
+    left.record.prompt === right.record.prompt &&
+    left.record.negativePrompt === right.record.negativePrompt &&
+    left.record.width === right.record.width &&
+    left.record.height === right.record.height &&
+    left.record.steps === right.record.steps &&
+    left.record.seed === right.record.seed &&
+    left.record.modelId === right.record.modelId
+  )
+}
+
+function coalesceLegacyRecords(
+  records: readonly LegacyGalleryRecord[]
+): readonly LegacyGalleryRecord[] {
+  const byId = new Map<string, LegacyGalleryRecord>()
+  for (const item of records) {
+    const current = byId.get(item.record.id)
+    if (!current) {
+      byId.set(item.record.id, item)
+      continue
+    }
+    const relationsConflict =
+      current.record.conversationId !== null &&
+      item.record.conversationId !== null &&
+      current.record.conversationId !== item.record.conversationId
+    if (!sameGeneration(current, item) || relationsConflict) {
+      throw new Error(`Generated image ${item.record.id} has conflicting legacy records.`)
+    }
+    if (current.record.conversationId === null && item.record.conversationId !== null) {
+      byId.set(item.record.id, item)
+    }
+  }
+  return [...byId.values()]
 }
 
 async function readLegacyRecords(): Promise<readonly LegacyGalleryRecord[]> {
@@ -92,7 +135,7 @@ async function readLegacyRecords(): Promise<readonly LegacyGalleryRecord[]> {
     if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return []
     throw cause
   }
-  return Promise.all(
+  const records = await Promise.all(
     names
       .filter((name) => isGeneratedImageFile(name) && !name.startsWith('preview-'))
       .sort((left, right) => left.localeCompare(right, 'en'))
@@ -101,6 +144,7 @@ async function readLegacyRecords(): Promise<readonly LegacyGalleryRecord[]> {
         return imagePath ? [legacyRecord(imagePath)] : []
       })
   )
+  return records.filter((record): record is LegacyGalleryRecord => record !== null)
 }
 
 function imagePart(record: GeneratedImageRecord): PortableMessageContentPart {
@@ -143,19 +187,24 @@ function migratedContent(
   return [...current, imagePart(record)]
 }
 
-async function migrateMessageRelation(item: LegacyGalleryRecord): Promise<void> {
-  if (!item.messageId) return
+async function migrateMessageRelation(item: LegacyGalleryRecord): Promise<LegacyGalleryRecord> {
+  if (!item.messageId) return item
   const snapshot = desktopWorkspaceContent.snapshot()
   if (snapshot.status !== 'ready') {
     throw new Error('Workspace Content is not ready for gallery migration.')
   }
   const message = snapshot.messages.find((candidate) => candidate.id === item.messageId)
-  if (!message) throw new Error(`Generated image message ${item.messageId} was not found.`)
+  if (!message) {
+    console.warn(
+      `[gallery-migration] importing generated image ${item.record.id} without its missing legacy message ${item.messageId}`
+    )
+    return { ...item, record: { ...item.record, conversationId: null } }
+  }
   if (message.conversationId !== item.record.conversationId) {
     throw new Error(`Generated image ${item.record.id} has a conflicting message conversation.`)
   }
   const content = migratedContent(message, item.record)
-  if (content === message.portable.content) return
+  if (content === message.portable.content) return item
   const outcome = await desktopWorkspaceContent.execute({
     type: 'update_message',
     origin: 'migration',
@@ -163,6 +212,7 @@ async function migrateMessageRelation(item: LegacyGalleryRecord): Promise<void> 
     portable: { ...message.portable, content }
   })
   if (!outcome.ok) throw new Error(outcome.failure.message)
+  return item
 }
 
 /** Import the old sidecar inventory exactly once through Shared validation and conflict policy. */
@@ -171,9 +221,9 @@ export async function migrateGeneratedImageSidecars(input: {
   readonly gallery: GeneratedImageGalleryFacade
 }): Promise<void> {
   if (input.repository.migrationComplete()) return
-  const legacy = await readLegacyRecords()
-  for (const item of legacy) await migrateMessageRelation(item)
-  const outcome = await input.gallery.importLegacy(legacy.map((item) => item.record))
+  const legacy = coalesceLegacyRecords(await readLegacyRecords())
+  const migrated = await Promise.all(legacy.map(migrateMessageRelation))
+  const outcome = await input.gallery.importLegacy(migrated.map((item) => item.record))
   if (!outcome.ok) throw new Error(outcome.failure.message)
   input.repository.markMigrationComplete()
 }

--- a/src/main/imagegen/gallery-migration.ts
+++ b/src/main/imagegen/gallery-migration.ts
@@ -23,7 +23,7 @@ interface MigrationRepository {
 
 interface LegacyGalleryRecord {
   readonly record: GeneratedImageRecord
-  readonly messageId?: string
+  readonly messageIds: readonly string[]
   readonly byteIdentity: string
 }
 
@@ -85,7 +85,7 @@ async function legacyRecord(imagePath: string): Promise<LegacyGalleryRecord | nu
       createdAt: sidecar.createdAt ?? stat.mtime.toISOString(),
       local: { path: imagePath, fileName: path.basename(imagePath) }
     }),
-    ...(sidecar.messageId ? { messageId: sidecar.messageId } : {})
+    messageIds: sidecar.messageId ? [sidecar.messageId] : []
   }
 }
 
@@ -119,9 +119,14 @@ function coalesceLegacyRecords(
     if (!sameGeneration(current, item) || relationsConflict) {
       throw new Error(`Generated image ${item.record.id} has conflicting legacy records.`)
     }
-    if (current.record.conversationId === null && item.record.conversationId !== null) {
-      byId.set(item.record.id, item)
-    }
+    byId.set(item.record.id, {
+      ...current,
+      record:
+        current.record.conversationId === null && item.record.conversationId !== null
+          ? item.record
+          : current.record,
+      messageIds: [...new Set([...current.messageIds, ...item.messageIds])]
+    })
   }
   return [...byId.values()]
 }
@@ -188,30 +193,31 @@ function migratedContent(
 }
 
 async function migrateMessageRelation(item: LegacyGalleryRecord): Promise<LegacyGalleryRecord> {
-  if (!item.messageId) return item
-  const snapshot = desktopWorkspaceContent.snapshot()
-  if (snapshot.status !== 'ready') {
-    throw new Error('Workspace Content is not ready for gallery migration.')
+  for (const messageId of item.messageIds) {
+    const snapshot = desktopWorkspaceContent.snapshot()
+    if (snapshot.status !== 'ready') {
+      throw new Error('Workspace Content is not ready for gallery migration.')
+    }
+    const message = snapshot.messages.find((candidate) => candidate.id === messageId)
+    if (!message) {
+      console.warn(
+        `[gallery-migration] importing generated image ${item.record.id} without its missing legacy message ${messageId}`
+      )
+      continue
+    }
+    if (message.conversationId !== item.record.conversationId) {
+      throw new Error(`Generated image ${item.record.id} has a conflicting message conversation.`)
+    }
+    const content = migratedContent(message, item.record)
+    if (content === message.portable.content) continue
+    const outcome = await desktopWorkspaceContent.execute({
+      type: 'update_message',
+      origin: 'migration',
+      messageId: message.id,
+      portable: { ...message.portable, content }
+    })
+    if (!outcome.ok) throw new Error(outcome.failure.message)
   }
-  const message = snapshot.messages.find((candidate) => candidate.id === item.messageId)
-  if (!message) {
-    console.warn(
-      `[gallery-migration] importing generated image ${item.record.id} without its missing legacy message ${item.messageId}`
-    )
-    return { ...item, record: { ...item.record, conversationId: null } }
-  }
-  if (message.conversationId !== item.record.conversationId) {
-    throw new Error(`Generated image ${item.record.id} has a conflicting message conversation.`)
-  }
-  const content = migratedContent(message, item.record)
-  if (content === message.portable.content) return item
-  const outcome = await desktopWorkspaceContent.execute({
-    type: 'update_message',
-    origin: 'migration',
-    messageId: message.id,
-    portable: { ...message.portable, content }
-  })
-  if (!outcome.ok) throw new Error(outcome.failure.message)
   return item
 }
 

--- a/src/main/models-manager.ts
+++ b/src/main/models-manager.ts
@@ -36,7 +36,7 @@ import {
   isChatLoadable,
   visionStatus,
   projectorToHeal,
-  isProjectorFileName,
+  isModelProjectorFile,
   modelSelectionRefusal,
   specialistReclassificationModality,
   transferredProjectorRepair,
@@ -169,11 +169,11 @@ export class ModelIdentityResolutionError extends Error {
 }
 
 function downloadedPrimary(model: DownloadedModel): string | undefined {
-  return model.files.find((name) => !isProjectorFileName(name)) ?? model.files[0]
+  return model.files.find((name) => !isModelProjectorFile(name)) ?? model.files[0]
 }
 
 function downloadedProjector(model: DownloadedModel): string | undefined {
-  return model.files.find(isProjectorFileName)
+  return model.files.find(isModelProjectorFile)
 }
 
 /** A route id, or any id that names a remote route, is already canonical (the workspace decides). */

--- a/src/main/startup-projection.ts
+++ b/src/main/startup-projection.ts
@@ -68,13 +68,9 @@ export function startupPhase(input: {
   if (input.stages.some((report) => report.required && settledBadly(report))) return 'failed'
   if (input.stages.some((report) => report.status === 'running')) return 'pending'
   if (input.applicationStatus !== 'running') return 'pending'
-  // `late` is deliberately degradation and not failure: something the product needs did arrive,
-  // just after its deadline, and a required stage that eventually settles must not leave the app
-  // reading as permanently failed while it is demonstrably running.
-  if (
-    input.degraded.length > 0 ||
-    input.stages.some((report) => settledBadly(report) || report.status === 'late')
-  ) {
+  // A late stage remains in the retained diagnostic history, but it is no longer an active
+  // degradation after it settles. Any real capability loss remains present in `degraded`.
+  if (input.degraded.length > 0 || input.stages.some((report) => settledBadly(report))) {
     return 'degraded'
   }
   return 'ready'

--- a/src/main/startup-stages.ts
+++ b/src/main/startup-stages.ts
@@ -159,8 +159,11 @@ export async function runStartupStage<T>(stage: StartupStage<T>): Promise<Startu
   // running, the stage reading as pending forever, and `runIndependentStartupStages` rejecting
   // early instead of collecting a typed failure.
   const work = Promise.resolve().then(() => stage.run(context))
-  stage.observeWork?.(work)
+  // This independent rejection observer remains attached if observeWork itself throws before the
+  // stage reaches Promise.race. Awaiting the original promise below still preserves its outcome.
+  void work.catch(() => undefined)
   try {
+    stage.observeWork?.(work)
     const outcome = await Promise.race([work.then((value) => ({ value }) as const), deadline])
     const durationMs = Date.now() - startedAt
     if (outcome === 'timeout') {

--- a/src/main/startup-stages.ts
+++ b/src/main/startup-stages.ts
@@ -92,6 +92,8 @@ export interface StartupStage<T> {
    * lands. Everything else defaults to refusing late effects.
    */
   readonly lateEffectIsRecoverable?: boolean
+  /** Observe the real work promise when another lifecycle must remain blocked until it settles. */
+  readonly observeWork?: (work: Promise<T>) => void
   readonly run: (context: StartupStageContext) => Promise<T>
 }
 
@@ -157,6 +159,7 @@ export async function runStartupStage<T>(stage: StartupStage<T>): Promise<Startu
   // running, the stage reading as pending forever, and `runIndependentStartupStages` rejecting
   // early instead of collecting a typed failure.
   const work = Promise.resolve().then(() => stage.run(context))
+  stage.observeWork?.(work)
   try {
     const outcome = await Promise.race([work.then((value) => ({ value }) as const), deadline])
     const durationMs = Date.now() - startedAt


### PR DESCRIPTION
## Summary
- wire the Desktop Pro CLIP projector transfer changes
- register the application before startup adapters bind
- serialize initial model preparation
- recover legacy generated-image migration safely
- add focused startup integration coverage

## Dependencies
- https://github.com/off-grid-ai/shared/pull/10
- https://github.com/off-grid-ai/desktop-pro/pull/47

## Verification
- Desktop startup completed without banner or startup errors in manual testing
- pre-push typecheck and architecture checks passed
- 83 related Vitest files passed; 397 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by coordinating text-model preparation with application availability.
  * Improved migration of older generated images, including incomplete or duplicate records, while preserving recoverable data.
  * Applications now handle legacy generated images without model details more gracefully.
  * Improved restoration of message relationships for migrated generated images.
  * Startup status now more accurately reflects genuine failures and timeouts.

* **Tests**
  * Added integration coverage for startup adapter registration and legacy image handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->