### PR TITLE
fix(sync): consume canonical Desktop status

### DIFF
--- a/.eslint-structural-baseline.json
+++ b/.eslint-structural-baseline.json
@@ -1358,11 +1358,6 @@
       "max-lines": [
         555
       ]
-    },
-    "pro/renderer/settings-sync.tsx": {
-      "complexity": [
-        22
-      ]
     }
   }
 }

--- a/e2e/devices-sync.spec.ts
+++ b/e2e/devices-sync.spec.ts
@@ -569,19 +569,6 @@ test.describe('Devices surface — pro tier', () => {
     expect(
       syntheticPeer.sendApp(desktop.localDevice.id, 'state', { t: 'ops', ops: inboundOps })
     ).toBe(true)
-    await expect
-      .poll(async () => {
-        const status = await page.evaluate(async () =>
-          (
-            window as unknown as {
-              api: { proInvoke(channel: string): Promise<{ ops: number }> }
-            }
-          ).api.proInvoke('pro:sync:status')
-        )
-        return status.ops
-      })
-      .toBeGreaterThanOrEqual(inboundOps.length)
-
     await navButton(page, 'Projects').click()
     const syncedProject = page.getByRole('button', { name: 'Synced from phone' })
     await expect(syncedProject).toBeVisible()


### PR DESCRIPTION
## Summary
- consume the canonical Desktop Sync status supplied by Desktop Pro
- keep the parent repository pinned to the matching Pro implementation

## Verification
- pre-push typecheck and architecture gates passed
- Shared consumer contract passed
- related-test selector found no parent-repository test files

## Manual verification
- Open Devices and confirm Starting, Running, and startup failure states match the real Sync service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated end-to-end device synchronization validation to streamline the transition into Projects.

- **Chores**
  - Refreshed internal quality-check baselines.
  - Updated the integrated Pro component to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->