### PR TITLE
Route remote screen work to the selected server

### DIFF
--- a/src/main/__tests__/active-text-model-transport.integration.dbtest.ts
+++ b/src/main/__tests__/active-text-model-transport.integration.dbtest.ts
@@ -19,7 +19,7 @@ vi.mock('electron', () => ({
 
 import { llm } from '../llm'
 import {
-  getActiveRemoteVisionServer,
+  getSelectedRemoteVisionServer,
   removeRemoteVisionServer,
   setRemoteVisionServerSettings
 } from '../vision/remote-vision-server'
@@ -202,7 +202,7 @@ beforeAll(async () => {
     apiKey: 'test-api-key'
   })
   remoteServerId = settings.activeServerId ?? ''
-  const activeRemote = getActiveRemoteVisionServer()
+  const activeRemote = getSelectedRemoteVisionServer('text')
   if (!activeRemote) throw new Error('The selected remote fixture was not persisted.')
   await remoteReasoningMetadata(activeRemote)
 })
@@ -382,7 +382,7 @@ describe('active text model transport', () => {
     turns.push({ content: 'Partial remote answer.', hold: true })
     const controller = new AbortController()
 
-    const remote = getActiveRemoteVisionServer()
+    const remote = getSelectedRemoteVisionServer('text')
     expect(remote).not.toBeNull()
     const result = await llm.streamChatRemote(
       remote!,

--- a/src/main/__tests__/cache-cleanup.integration.test.ts
+++ b/src/main/__tests__/cache-cleanup.integration.test.ts
@@ -39,14 +39,22 @@ beforeEach(() => {
 
 describe('ephemeral cache cleanup', () => {
   it('allowlists only Electron cache data and reports reclaimed bytes (#134)', async () => {
-    await expect(clearEphemeralCache()).resolves.toEqual({ success: true, freedBytes: 8_192 })
+    await expect(clearEphemeralCache()).resolves.toEqual({
+      success: true,
+      freedBytes: 8_192,
+      incompleteDownloadsRemoved: 0
+    })
     expect(boundary.clearCalls).toEqual([{ dataTypes: ['cache'] }])
   })
 
   it('still clears when Electron cannot measure the cache size', async () => {
     boundary.measurementFails = true
 
-    await expect(clearEphemeralCache()).resolves.toEqual({ success: true, freedBytes: null })
+    await expect(clearEphemeralCache()).resolves.toEqual({
+      success: true,
+      freedBytes: null,
+      incompleteDownloadsRemoved: 0
+    })
     expect(boundary.clearCalls).toEqual([{ dataTypes: ['cache'] }])
   })
 

--- a/src/main/__tests__/model-selection-authority.integration.test.ts
+++ b/src/main/__tests__/model-selection-authority.integration.test.ts
@@ -74,9 +74,87 @@ afterAll(() => {
 
 afterEach(async () => {
   await Promise.all(applications.splice(0).map((application) => application.stop()))
+  fs.rmSync(path.join(modelDirectory, 'remote-vision-server.json'), { force: true })
+  fs.rmSync(path.join(modelDirectory, 'model-selections.json'), { force: true })
 })
 
 describe('Desktop active-model authority', () => {
+  it('routes through the selected second remote server and preserves it after restart', async () => {
+    fs.writeFileSync(
+      path.join(modelDirectory, 'remote-vision-server.json'),
+      JSON.stringify({
+        version: 4,
+        servers: [
+          {
+            id: 'remote-first',
+            name: 'First enabled server',
+            provider: 'custom',
+            endpoint: 'https://first.example/v1',
+            model: 'vision-first',
+            selections: { text: 'vision-first' },
+            catalog: {
+              text: [
+                {
+                  id: 'vision-first',
+                  name: 'Vision first',
+                  capabilities: { supportsVision: true }
+                }
+              ]
+            },
+            screenFramesAllowed: true
+          },
+          {
+            id: 'remote-second',
+            name: 'Selected second server',
+            provider: 'custom',
+            endpoint: 'https://second.example/v1',
+            model: 'vision-second',
+            selections: { text: 'vision-second' },
+            catalog: {
+              text: [
+                {
+                  id: 'vision-second',
+                  name: 'Vision second',
+                  capabilities: { supportsVision: true }
+                }
+              ]
+            },
+            screenFramesAllowed: true
+          }
+        ]
+      })
+    )
+    const ports = {
+      listCatalog: async () => [],
+      listInstalled: async () => [],
+      localTextRuntime: createFakeLocalTextRuntime().runtime
+    }
+    const firstApplication = await createModelsApplication(ports)
+    await firstApplication.models.refresh()
+    const secondRoute = firstApplication.models
+      .snapshot()
+      .inventory.find((model) => model.modality === 'text' && model.serverId === 'remote-second')
+    if (!secondRoute?.routeId) throw new Error('The second remote server route was not projected.')
+
+    await expect(
+      firstApplication.models.select({ modality: 'text', modelId: secondRoute.routeId })
+    ).resolves.toMatchObject({ ok: true })
+    const { getSelectedRemoteVisionServer } = await import('../vision/remote-vision-server')
+    expect(getSelectedRemoteVisionServer('text')).toMatchObject({
+      id: 'remote-second',
+      endpoint: 'https://second.example/v1'
+    })
+
+    await firstApplication.stop()
+    applications.splice(applications.indexOf(firstApplication), 1)
+    const restartedApplication = await createModelsApplication(ports)
+    await restartedApplication.models.refresh()
+    expect(getSelectedRemoteVisionServer('text')).toMatchObject({
+      id: 'remote-second',
+      endpoint: 'https://second.example/v1'
+    })
+  })
+
   it('uses the persisted route for inventory, runtime state, UI projection, and execution', async () => {
     const byKind = (kind: string): CatalogEntry => {
       const model = CATALOG.find(

--- a/src/main/__tests__/transferred-model-lifecycle.dbtest.ts
+++ b/src/main/__tests__/transferred-model-lifecycle.dbtest.ts
@@ -33,6 +33,7 @@ describe('transferred model lifecycle', () => {
     const { registerDesktopApplication } = await import('../composition/application-access')
     const { createDesktopModelTransferQueryPorts } =
       await import('../models/model-transfer-query-ports')
+    const { createDesktopModelControlPort } = await import('../models/desktop-model-control-port')
     const workspace = createDesktopModelWorkspacePorts({
       listCatalog: async () =>
         (await manager.getCatalog()).models as Awaited<
@@ -59,7 +60,8 @@ describe('transferred model lifecycle', () => {
         library: {
           ...manager.desktopModelLibraryPorts,
           transferable: createDesktopModelTransferQueryPorts()
-        }
+        },
+        control: createDesktopModelControlPort()
       }
     })
     registerDesktopApplication(application)
@@ -92,6 +94,12 @@ describe('transferred model lifecycle', () => {
     expect((await manager.getCatalog()).models).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: packageId, kind: 'vision' })])
     )
+    expect(application.models.snapshot().control.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: packageId, sourceModelId: familyId, kind: 'vision' })
+      ])
+    )
+    expect(application.models.snapshot().control.installed).toContain(packageId)
     expect(await manager.getVisionStatuses()).toMatchObject({
       [packageId]: { supportsVision: true, projectorInstalled: true }
     })

--- a/src/main/actions/remote-screen-gate.ts
+++ b/src/main/actions/remote-screen-gate.ts
@@ -1,17 +1,17 @@
 import type { ActionRecord, ExecuteResult } from '@offgrid/use'
 import { getComputerUseSettings } from '../computer-use-settings'
-import { getActiveRemoteVisionServer } from '../vision/remote-vision-server'
+import { getSelectedRemoteVisionServer } from '../vision/remote-vision-server'
 import { remoteScreenDecision, type ScreenTaskKind } from '../../shared/remote-screen-privacy'
 import { runWithRemoteScreenTaskSession } from './remote-screen-session'
 
 interface RemoteScreenGateDependencies {
   modelStrategy(): 'same_as_chat' | 'separate_specialist' | 'text_plus_specialist'
-  activeServer(): ReturnType<typeof getActiveRemoteVisionServer>
+  activeServer(): ReturnType<typeof getSelectedRemoteVisionServer>
 }
 
 const productionDependencies: RemoteScreenGateDependencies = {
   modelStrategy: () => getComputerUseSettings().modelStrategy,
-  activeServer: getActiveRemoteVisionServer
+  activeServer: () => getSelectedRemoteVisionServer('text')
 }
 
 /** Stop a screen task before its host captures or sends the first frame. */

--- a/src/main/actions/remote-screen-session.ts
+++ b/src/main/actions/remote-screen-session.ts
@@ -1,12 +1,12 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { ComputerUseModelStrategy } from '../../shared/computer-use-settings'
 import type { ScreenTaskKind } from '../../shared/remote-screen-privacy'
-import type { getActiveRemoteVisionServer } from '../vision/remote-vision-server'
+import type { getSelectedRemoteVisionServer } from '../vision/remote-vision-server'
 
 export interface RemoteScreenTaskSession {
   taskKind: ScreenTaskKind
   modelStrategy: ComputerUseModelStrategy
-  activeServer: ReturnType<typeof getActiveRemoteVisionServer>
+  activeServer: ReturnType<typeof getSelectedRemoteVisionServer>
 }
 
 const sessions = new AsyncLocalStorage<Readonly<RemoteScreenTaskSession>>()

--- a/src/main/cache-cleanup.ts
+++ b/src/main/cache-cleanup.ts
@@ -1,8 +1,6 @@
-// Cache cleanup is intentionally restricted to Chromium's explicitly classified
-// cache data. It never receives userData paths, so chats, projects, models, vault,
-// settings, and entitlement files are unreachable by construction.
 import { session } from 'electron'
 import type { CacheCleanupResultContract } from '../shared/ipc-contracts'
+import { desktopModels, modelsFailureMessage } from './composition/application-access'
 
 async function measuredCacheSize(): Promise<number | null> {
   try {
@@ -21,6 +19,21 @@ export async function clearEphemeralCache(): Promise<CacheCleanupResultContract>
   const after = await measuredCacheSize()
   return {
     success: true,
-    freedBytes: before == null || after == null ? null : Math.max(0, before - after)
+    freedBytes: before == null || after == null ? null : Math.max(0, before - after),
+    incompleteDownloadsRemoved: 0
+  }
+}
+
+/** Clear disposable browser data and inactive model-download artifacts through their owners. */
+export async function clearTemporaryStorage(): Promise<CacheCleanupResultContract> {
+  const downloads = await desktopModels.clearInactiveDownloads()
+  if (!downloads.ok) throw new Error(modelsFailureMessage(downloads.failure))
+
+  const cache = await clearEphemeralCache()
+  const knownFreedBytes = downloads.value.freedBytes + (cache.freedBytes ?? 0)
+  return {
+    success: true,
+    freedBytes: cache.freedBytes == null && downloads.value.freedBytes === 0 ? null : knownFreedBytes,
+    incompleteDownloadsRemoved: downloads.value.count
   }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1510,7 +1510,7 @@ export function setupIPC(): void {
     import('./models-manager').then((m) => m.deleteOrphans())
   )
   ipcMain.handle(CACHE_CLEANUP_CHANNEL, () =>
-    import('./cache-cleanup').then((m) => m.clearEphemeralCache())
+    import('./cache-cleanup').then((m) => m.clearTemporaryStorage())
   )
   // Import a local .gguf from disk (file picker → validate → copy → register).
   ipcMain.handle('models:import', async (): Promise<ModelImportResultContract> => {

--- a/src/main/vision/grounder-loader.ts
+++ b/src/main/vision/grounder-loader.ts
@@ -24,7 +24,7 @@ import type { ModelsFacade } from '@offgrid/application'
 import { llm } from '../llm'
 import { isGrounderActive } from './vision-model-notice'
 import { getComputerUseSettings } from '../computer-use-settings'
-import { getActiveRemoteVisionServer } from './remote-vision-server'
+import { getSelectedRemoteVisionServer } from './remote-vision-server'
 import {
   currentRemoteScreenTaskSession,
   runWithRemoteScreenTaskSession
@@ -98,7 +98,7 @@ const productionGrounderDependencies: GrounderRunnerDependencies = {
   activeModelId: () => desktopModels.activeModelId('text'),
   activeRemote: () => {
     const session = currentRemoteScreenTaskSession()
-    return session ? session.activeServer : getActiveRemoteVisionServer()
+    return session ? session.activeServer : getSelectedRemoteVisionServer('text')
   },
   isGrounder: isGrounderActive,
   load: productionGrounderLifecycle.load,

--- a/src/main/vision/remote-vision-server.ts
+++ b/src/main/vision/remote-vision-server.ts
@@ -3,9 +3,10 @@ import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { modelsDir } from '../runtime-env'
 import {
+  GENERATION_PROFILES,
   REMOTE_FETCH_REDIRECT_POLICY,
   type RemoteServerApplicationPorts,
-  activeRemoteServer,
+  firstEnabledRemoteServer,
   canReconcileCredentialedEndpoint,
   catalogFromDiscovery,
   defaultRemoteSelections,
@@ -17,6 +18,7 @@ import {
   remoteAuthorizationHeaders,
   remoteErrorBodyMessage,
   remoteModelListUrl,
+  type ModelModality,
   type RemoteModelCatalog,
   type RemoteModalitySelections,
   type PersistedRemoteServer
@@ -56,7 +58,8 @@ interface StoredRemoteVisionServer {
 
 /**
  * On disk since version 4. Files written before 2026-09-03 also carry an `activeServerId`; the
- * active server is derived from the list (shared `activeRemoteServer`), so that field is read past.
+ * settings fallback is derived from the list (shared `firstEnabledRemoteServer`), so that field is
+ * read past. Execution never uses this fallback.
  */
 interface StoredRemoteVisionConfig {
   version: 4
@@ -129,7 +132,7 @@ function sharedConfiguration(
 ): ReturnType<typeof migrateRemoteServerConfiguration> {
   return {
     version: 1,
-    activeServerId: activeRemoteServer(stored.servers)?.id ?? null,
+    activeServerId: firstEnabledRemoteServer(stored.servers)?.id ?? null,
     servers: stored.servers.map((server) => ({ ...server, provider: sharedProvider(server.provider) }))
   }
 }
@@ -273,7 +276,7 @@ export const desktopRemoteServerPorts: Omit<RemoteServerApplicationPorts, 'selec
 
 export function getRemoteVisionServerSettings(): RemoteVisionServerSettings {
   const stored = readStored()
-  const active = activeRemoteServer(stored.servers)
+  const active = firstEnabledRemoteServer(stored.servers)
   return {
     provider: active?.provider ?? 'local',
     endpoint: active?.endpoint ?? '',
@@ -284,16 +287,21 @@ export function getRemoteVisionServerSettings(): RemoteVisionServerSettings {
   }
 }
 
-export function getActiveRemoteVisionServer(): RemoteVisionServerConnection | null {
-  const stored = readStored()
-  const active = activeRemoteServer(stored.servers)
-  return active ? { ...active, apiKey: transportApiKey(active) } : null
-}
-
 /** Resolve one persisted server for a route selected by the shared model service. */
 export function getRemoteVisionServer(serverId: string): RemoteVisionServerConnection | null {
   const server = readStored().servers.find((candidate) => candidate.id === serverId)
   return server ? { ...server, apiKey: transportApiKey(server) } : null
+}
+
+/** Join Shared's strict selected route to this device's remote-server transport. */
+export function getSelectedRemoteVisionServer(
+  modality: ModelModality
+): RemoteVisionServerConnection | null {
+  const selected = desktopModels.resolve({
+    modality,
+    allowFallback: GENERATION_PROFILES.chat.allowFallback
+  }).selected
+  return selected?.serverId ? getRemoteVisionServer(selected.serverId) : null
 }
 
 export async function setRemoteVisionServerSettings(

--- a/src/main/vision/vision-task-model-strategy.ts
+++ b/src/main/vision/vision-task-model-strategy.ts
@@ -24,7 +24,7 @@ import type {
   VisionPolicyInput
 } from './model-adapters/types'
 import { createVisionGrounder } from './vision-policy-runner'
-import { getActiveRemoteVisionServer } from './remote-vision-server'
+import { getSelectedRemoteVisionServer } from './remote-vision-server'
 import type { VisionGroundingInput, VisionGroundingResult } from './vision-agent'
 import { currentRemoteScreenTaskSession } from '../actions/remote-screen-session'
 import {
@@ -70,7 +70,7 @@ const productionDependencies: VisionTaskModelStrategyDependencies = {
   activeArtifacts: () => llm.activeModelArtifacts(),
   activeRemote: () => {
     const session = currentRemoteScreenTaskSession()
-    return session ? session.activeServer : getActiveRemoteVisionServer()
+    return session ? session.activeServer : getSelectedRemoteVisionServer('text')
   },
   selectedChatId: getActiveModel,
   selectedSpecialistId: selectedGrounderModelId,

--- a/src/renderer/src/components/setup/CacheCleanupControl.tsx
+++ b/src/renderer/src/components/setup/CacheCleanupControl.tsx
@@ -3,7 +3,7 @@ import { Broom } from '@phosphor-icons/react'
 import type { CacheCleanupResultContract } from '../../../../shared/ipc-contracts'
 import { formatStorageBytes } from './storage-format'
 
-/** Cache-only cleanup control. Durable-store reassurance stays beside the action. */
+/** One cleanup control for disposable cache and inactive model downloads. */
 export function CacheCleanupControl(): React.ReactElement {
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
@@ -16,9 +16,12 @@ export function CacheCleanupControl(): React.ReactElement {
       const reclaimed = result.freedBytes
         ? ` ${formatStorageBytes(result.freedBytes)} reclaimed.`
         : ''
-      setNotice(`Temporary cache cleared.${reclaimed} Your data and models were kept.`)
+      const downloads = result.incompleteDownloadsRemoved
+        ? ` ${result.incompleteDownloadsRemoved} partial model download${result.incompleteDownloadsRemoved === 1 ? '' : 's'} removed.`
+        : ''
+      setNotice(`Temporary cache cleared.${reclaimed}${downloads} Installed models were kept.`)
     } catch {
-      setNotice('Cache could not be cleared. Your data and models were not changed.')
+      setNotice('Cleanup could not be completed. Installed models and your data were kept.')
     } finally {
       setBusy(false)
     }
@@ -29,7 +32,7 @@ export function CacheCleanupControl(): React.ReactElement {
       <div className="min-w-0">
         <div className="text-[11px] text-neutral-300">Temporary app cache</div>
         <div className="text-[10px] text-neutral-600">
-          Safe to clear. Chats, projects, models, vault, settings, and Pro access stay.
+          Safe to clear. Partial model downloads are removed. Installed models and your data stay.
         </div>
         {notice && (
           <div role="status" className="mt-1 text-[10px] text-neutral-500">

--- a/src/renderer/src/components/setup/__tests__/StorageUsage.integration.test.tsx
+++ b/src/renderer/src/components/setup/__tests__/StorageUsage.integration.test.tsx
@@ -97,7 +97,11 @@ describe('rendered storage usage', () => {
           projection
         })
       ),
-      clearAppCache: vi.fn(async () => ({ success: true, freedBytes: 3_000_000 }))
+      clearAppCache: vi.fn(async () => ({
+        success: true,
+        freedBytes: 3_000_000,
+        incompleteDownloadsRemoved: 2
+      }))
     }
     ;(globalThis as unknown as { window: Window }).window.api = api as never
   })
@@ -333,14 +337,14 @@ describe('rendered storage usage', () => {
     })
   })
 
-  it('clears only temporary cache and explains which durable stores remain (#134)', async () => {
+  it('clears temporary cache and partial model downloads while preserving installed models', async () => {
     const user = userEvent.setup()
     render(<StoragePanel />)
 
     expect(await screen.findByText('Temporary app cache')).toBeTruthy()
     expect(
       screen.getByText(
-        'Safe to clear. Chats, projects, models, vault, settings, and Pro access stay.'
+        'Safe to clear. Partial model downloads are removed. Installed models and your data stay.'
       )
     ).toBeTruthy()
 
@@ -348,7 +352,7 @@ describe('rendered storage usage', () => {
 
     expect(api.clearAppCache).toHaveBeenCalledTimes(1)
     expect((await screen.findByRole('status')).textContent).toBe(
-      'Temporary cache cleared. 3 MB reclaimed. Your data and models were kept.'
+      'Temporary cache cleared. 3 MB reclaimed. 2 partial model downloads removed. Installed models were kept.'
     )
   })
 
@@ -360,19 +364,23 @@ describe('rendered storage usage', () => {
     await user.click(await screen.findByRole('button', { name: 'Clear cache' }))
 
     expect((await screen.findByRole('status')).textContent).toBe(
-      'Cache could not be cleared. Your data and models were not changed.'
+      'Cleanup could not be completed. Installed models and your data were kept.'
     )
   })
 
   it('reports successful cleanup when Electron cannot measure reclaimed bytes', async () => {
-    api.clearAppCache.mockResolvedValue({ success: true, freedBytes: null })
+    api.clearAppCache.mockResolvedValue({
+      success: true,
+      freedBytes: null,
+      incompleteDownloadsRemoved: 0
+    })
     const user = userEvent.setup()
     render(<StoragePanel />)
 
     await user.click(await screen.findByRole('button', { name: 'Clear cache' }))
 
     expect((await screen.findByRole('status')).textContent).toBe(
-      'Temporary cache cleared. Your data and models were kept.'
+      'Temporary cache cleared. Installed models were kept.'
     )
   })
 })

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -165,8 +165,10 @@ export interface SystemHealthContract {
 
 export interface CacheCleanupResultContract {
   success: true
-  /** HTTP cache bytes reclaimed when Electron can measure them; null otherwise. */
+  /** Known disposable bytes reclaimed; null when no owner can measure them. */
   freedBytes: number | null
+  /** Failed, cancelled, or interrupted model downloads removed by Shared Models. */
+  incompleteDownloadsRemoved: number
 }
 
 export const CACHE_CLEANUP_CHANNEL = 'storage:clear-cache'


### PR DESCRIPTION
## Outcome

Routes remote vision, grounding, screen, and Computer Use work through the server selected by Shared for the requested route. The first enabled server remains settings-only and cannot receive screen data as an execution fallback.

## Dependencies

- Shared: https://github.com/off-grid-ai/shared/pull/13
- Desktop Pro: https://github.com/off-grid-ai/desktop-pro/pull/50

## Proof

- Second enabled server is selected and used
- Selection remains effective after application restart
- 13 focused Desktop routing and transport tests pass
- 9 focused Desktop Pro settings tests pass
- Focused type checks and lint pass
- Desktop pre-push type, architecture, and related test gates pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Remote vision servers can now be selected by modality, including text-based tasks.
  - Remote server selections persist across application restarts.
  - Temporary storage cleanup removes incomplete model downloads and reports the number removed.

- **Bug Fixes**
  - Cleanup messaging now clearly distinguishes temporary files and partial downloads from installed models and user data.

- **Tests**
  - Added coverage for server selection, persistence, restart behavior, and storage cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->