### PR TITLE
Place Explore beside Chat and record take-over flow

### DIFF
--- a/.contextignore
+++ b/.contextignore
@@ -1,0 +1,11 @@
+# Lockfiles - generated, no semantic value
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+*.lock
+
+# Minified vendor bundles (mermaid/babel/react) - 6.3MB of unreadable minified JS
+resources/artifacts/**
+
+# Indexed separately as its own codebase
+pro/**

--- a/docs/flows/computer-use-take-over-and-continue.md
+++ b/docs/flows/computer-use-take-over-and-continue.md
@@ -1,0 +1,44 @@
+# Accepted flow: Take Over and Continue (Computer Use)
+
+Status: accepted by pm (Wanda). Owner of the rules: `@offgrid/automation` task state and input lease.
+Desktop is a thin consumer: it shows the state and forwards the person's choice.
+
+## The flow
+
+1. A person watches a Computer Use task run. The supervisor shows the task is running.
+2. The person presses **Take Over**.
+3. The agent stops acting at once. The screen says the person has control.
+4. The person uses the keyboard and mouse themselves. No agent click, type, or scroll happens.
+5. The person presses **Continue**.
+6. The agent looks at the screen again first, then carries on the same task from where it is.
+7. Nothing the agent decided before the take over is ever acted on after it.
+
+## Acceptance rules
+
+- A1 Agent stop: after Take Over the agent performs no input at all. Any action already in
+  flight is dropped, not delivered late.
+- A2 Visible ownership: while the person holds control the supervisor states it in plain words,
+  for example "You have control of this computer". The Continue choice is offered.
+- A3 Same task: Continue carries on the same task and the same goal. It does not start a new
+  task, does not reset progress, and does not lose earlier steps.
+- A4 Fresh look first: after Continue the agent must take a new screenshot before it may act.
+  It must never act on the picture it held before the take over.
+- A5 Stale action rejected: an action prepared before the take over is refused after it, even if
+  it arrives late. The refusal is silent to the person and the task keeps running.
+- A6 Stop still wins: Stop remains final. Continue cannot revive a stopped or failed task.
+- A7 One truth: only the shared automation task owns status and control ownership. The desktop
+  screen never shows control it does not hold.
+
+## How each rule is proved
+
+- A1, A5: the shared input lease changes owner and its epoch number increases, so any older
+  action is rejected. Prove with the automation task tests and a live take over during a click.
+- A2: prove by eye on the running supervisor screen.
+- A3: prove the task id and goal are unchanged after Continue.
+- A4: prove the first thing after Continue is a new screenshot, not an action.
+- A6: prove Continue after Stop is refused.
+
+## Out of scope
+
+Pause is a different choice: it parks the agent but does not hand input to the person. This flow
+covers Take Over and Continue only.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -869,11 +869,6 @@ function AppContent(): React.ReactElement {
       label: 'Discover',
       icon: <IconSparkles className="h-5 w-5 shrink-0" />,
       items: navItems(
-        {
-          label: 'Explore',
-          icon: <IconCompass className="h-5 w-5 shrink-0" />,
-          view: 'explore' as ViewMode
-        },
         proItem('search'),
         proItem('day'),
         proItem('replay'),
@@ -896,6 +891,11 @@ function AppContent(): React.ReactElement {
           label: 'Chat',
           icon: <IconMessageCircle className="h-5 w-5 shrink-0" />,
           view: 'memory-chat' as ViewMode
+        },
+        {
+          label: 'Explore',
+          icon: <IconCompass className="h-5 w-5 shrink-0" />,
+          view: 'explore' as ViewMode
         },
         {
           label: 'Tasks',

--- a/src/renderer/src/__tests__/App.navigation-order.integration.test.tsx
+++ b/src/renderer/src/__tests__/App.navigation-order.integration.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  installAppBoundary,
+  installAppBrowserBoundary,
+  installAppStorage
+} from './harness/app-boundary'
+
+let App: typeof import('../App').default
+
+describe('<App/> navigation order integration', () => {
+  beforeAll(async () => {
+    installAppBoundary()
+    installAppBrowserBoundary()
+    ;({ default: App } = await import('../App'))
+  }, 30_000)
+
+  beforeEach(() => {
+    installAppStorage().setItem('onboarding_completed', 'true')
+    window.history.replaceState(null, '', '/models')
+    installAppBrowserBoundary()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('places Explore directly after Chat and opens it from the Work section', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    const navigation = await screen.findByRole('navigation', { name: 'Primary navigation' })
+    await user.hover(navigation)
+    await waitFor(() => expect(navigation.getAttribute('aria-expanded')).toBe('true'))
+
+    const discover = within(navigation).getByRole('group', { name: 'Discover' })
+    const work = within(navigation).getByRole('group', { name: 'Work' })
+    const chat = within(work).getByRole('button', { name: 'Chat' })
+    const explore = within(work).getByRole('button', { name: 'Explore' })
+    const workButtons = within(work).getAllByRole('button')
+
+    expect(within(discover).queryByRole('button', { name: 'Explore' })).toBeNull()
+    expect(workButtons.indexOf(explore)).toBe(workButtons.indexOf(chat) + 1)
+
+    await user.click(explore)
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Explore' })).toBeTruthy()
+    expect(window.location.pathname).toBe('/explore')
+  }, 30_000)
+})


### PR DESCRIPTION
## Summary
- move Explore closer to Chat in desktop navigation
- add integration coverage for navigation order
- record the accepted Computer Use take-over and continue flow
- update the desktop Pro pointer for semantic-index configuration

## Related PR
- off-grid-ai/desktop-pro#54

## Verification
- desktop pre-push typecheck passed
- model architecture check passed
- related Vitest projects passed: 3 files, 7 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Moved Explore from the Discover section to the Work section.
  * Explore now appears directly after Chat and continues to open the Explore page.

* **Documentation**
  * Added documentation for the Computer Use “Take Over and Continue” workflow, including human handoff and task continuation behavior.

* **Maintenance**
  * Updated project indexing and ignore rules for selected files and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->