### PR TITLE
perf(startup): open the shell before optional work

### DIFF
--- a/e2e/app-launch.spec.ts
+++ b/e2e/app-launch.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test, type ElectronApplication, type Page } from '@playwright/test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { launchOffGrid } from './helpers/launch'
+
+let app: ElectronApplication
+let page: Page
+let userDataDir: string
+
+test.beforeAll(async () => {
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'offgrid-app-launch-'))
+  app = await launchOffGrid({
+    env: {
+      ...process.env,
+      OFFGRID_USER_DATA: userDataDir,
+      OFFGRID_PRO: '0',
+      NODE_ENV: 'production'
+    }
+  })
+  page = await app.firstWindow()
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  fs.rmSync(userDataDir, { recursive: true, force: true })
+})
+
+test('the first window renders and startup settles without blocking it', async () => {
+  await page.waitForLoadState('domcontentloaded')
+  await expect(page.locator('#root')).not.toBeEmpty()
+  await expect(
+    page.getByText('Off Grid AI Desktop could not finish startup. Restart the app.')
+  ).toHaveCount(0)
+  await expect(page.getByText(/did not finish|took longer than expected/)).toHaveCount(0, {
+    timeout: 15_000
+  })
+})

--- a/src/main/__tests__/startup-projection.test.ts
+++ b/src/main/__tests__/startup-projection.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { createStartupProjection } from '../startup-projection'
+
+describe('startup projection', () => {
+  it('returns to ready when every running stage completes', () => {
+    const projection = createStartupProjection()
+
+    projection.stageStarted({ name: 'core', required: true })
+    projection.stageStarted({ name: 'optional', required: false })
+    expect(projection.snapshot().phase).toBe('pending')
+    expect(projection.snapshot().running).toEqual(['core', 'optional'])
+
+    projection.stageSettled({
+      name: 'core',
+      status: 'completed',
+      required: true,
+      durationMs: 4
+    })
+    projection.stageSettled({
+      name: 'optional',
+      status: 'completed',
+      required: false,
+      durationMs: 8
+    })
+
+    expect(projection.snapshot()).toMatchObject({ phase: 'ready', running: [] })
+  })
+
+  it('keeps required failures distinct from optional degradation', () => {
+    const optional = createStartupProjection()
+    optional.stageSettled({
+      name: 'optional',
+      status: 'timeout',
+      required: false,
+      durationMs: 20,
+      error: 'exceeded 20ms'
+    })
+    expect(optional.snapshot().phase).toBe('degraded')
+
+    const required = createStartupProjection()
+    required.stageSettled({
+      name: 'required',
+      status: 'failed',
+      required: true,
+      durationMs: 2,
+      error: 'failed'
+    })
+    expect(required.snapshot().phase).toBe('failed')
+  })
+
+  it('publishes increasing revisions and stops after unsubscribe', () => {
+    const projection = createStartupProjection()
+    const revisions: number[] = []
+    const unsubscribe = projection.subscribe((snapshot) => revisions.push(snapshot.revision))
+
+    projection.stageStarted({ name: 'core', required: true })
+    projection.stageSettled({
+      name: 'core',
+      status: 'completed',
+      required: true,
+      durationMs: 1
+    })
+    unsubscribe()
+    projection.stageStarted({ name: 'later', required: false })
+
+    expect(revisions).toEqual([1, 2])
+  })
+})

--- a/src/main/__tests__/startup-stages.test.ts
+++ b/src/main/__tests__/startup-stages.test.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runStartupStage } from '../startup-stages'
+import { startupProjection } from '../startup-projection'
+
+const delay = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+let temporaryRoot = ''
+const originalLogPath = process.env.OFFGRID_DIAGNOSTIC_LOG
+
+beforeEach(() => {
+  temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'offgrid-startup-test-'))
+  process.env.OFFGRID_DIAGNOSTIC_LOG = path.join(temporaryRoot, 'startup.log')
+})
+
+afterEach(() => {
+  if (originalLogPath === undefined) delete process.env.OFFGRID_DIAGNOSTIC_LOG
+  else process.env.OFFGRID_DIAGNOSTIC_LOG = originalLogPath
+  fs.rmSync(temporaryRoot, { recursive: true, force: true })
+})
+
+describe('startup stages', () => {
+  it('refuses a guarded change after the stage deadline', async () => {
+    let applied = false
+    const stageName = `guarded-${crypto.randomUUID()}`
+
+    const result = await runStartupStage({
+      name: stageName,
+      deadlineMs: 5,
+      lateEffect: 'guard',
+      run: async (context) => {
+        await delay(20)
+        context.commit('apply late result', () => {
+          applied = true
+        })
+      }
+    })
+    await delay(30)
+
+    expect(result).toMatchObject({ ok: false, reason: 'timeout' })
+    expect(applied).toBe(false)
+    expect(
+      startupProjection.snapshot().stages.find((stage) => stage.name === stageName)?.status
+    ).toBe('timeout')
+  })
+
+  it('records an allowed late result without leaving startup pending', async () => {
+    const stageName = `keep-${crypto.randomUUID()}`
+
+    const result = await runStartupStage({
+      name: stageName,
+      deadlineMs: 5,
+      lateEffect: 'keep',
+      run: async () => delay(20)
+    })
+    await delay(30)
+
+    expect(result).toMatchObject({ ok: false, reason: 'timeout' })
+    expect(
+      startupProjection.snapshot().stages.find((stage) => stage.name === stageName)?.status
+    ).toBe('late')
+    expect(startupProjection.snapshot().running).not.toContain(stageName)
+  })
+
+  it('turns a synchronous stage exception into a typed failure', async () => {
+    const result = await runStartupStage({
+      name: `failure-${crypto.randomUUID()}`,
+      deadlineMs: 50,
+      required: true,
+      lateEffect: 'guard',
+      run: () => {
+        throw new Error('startup failed')
+      }
+    })
+
+    expect(result).toMatchObject({ ok: false, reason: 'failed', error: 'startup failed' })
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,6 +65,8 @@ import {
   installIpcDiagnostics,
   writeDiagnosticLog
 } from './diagnostics-log'
+import { registerStartupStatusIpc } from './startup-ipc'
+import { runIndependentStartupStages, runStartupStage } from './startup-stages'
 import {
   applicationShutdown,
   commitApplicationRelaunch,
@@ -402,97 +404,181 @@ app.whenReady().then(async () => {
     optimizer.watchWindowShortcuts(window)
   })
 
-  // 2. Setup IPC Handlers (core) + the local model gateway
-  try {
-    installIpcDiagnostics(ipcMain)
-    // Licensing first: load the cached Keygen entitlement into memory and register
-    // the SYNC `pro:is-enabled` handler BEFORE createWindow() (line below) so the
-    // preload's sendSync resolves and window.api.isPro reflects the real license.
-    await loadProEntitlementProvider()
-    initLicensing()
-    await revalidateProEntitlement('launch')
-    setupLicenseIpc()
-    const entitlementRefresh = setInterval(() => {
-      refreshCachedProEntitlement()
-      void revalidateProEntitlement('foreground')
-    }, PERSONAL_MESH_ENTITLEMENT_REVALIDATION_INTERVAL_MS)
-    entitlementRefresh.unref()
-    applicationShutdown.register({
-      name: 'pro:entitlement-refresh',
-      shutdown: () => clearInterval(entitlementRefresh)
-    })
-    setupIPC()
-    setupRagIPC()
-    setupMcpIpc() // basic MCP connectors (management + chat tool extension)
-    registerNativeActionTools(registerToolExtension) // the assistant's tools (macOS full set; Windows Outlook subset)
-    const { registerActionsIpc } = await import('./actions/actions-ipc')
-    registerActionsIpc() // Approval UX v2: inline gate cards + outcome/undo feed
-    const { registerBrowserViewIpc } = await import('./browser/browser-host')
-    registerBrowserViewIpc() // dock the live browser view to the pane's region
-    const { registerVisionIpc } = await import('./vision/vision-controller')
-    registerVisionIpc() // the vision rail's supervisor Stop/Pause/Resume
-    const { registerSupervisorWindowIpc } = await import('./vision/supervisor-window')
-    registerSupervisorWindowIpc()
-    const { registerTaskHistoryIpc } = await import('./tasks/task-history-ipc')
-    registerTaskHistoryIpc() // one durable Web Use + Computer Use history
-    setupDesktopBackupIPC()
-    // one OpenAI-compatible local gateway (LLM + STT); auto-picks a free port. Async, so handle a
-    // rejection on the promise (a try/catch around a fire-and-forget async call can't catch it).
-    startModelServer().catch((e) => console.error('[model-server] start failed', e))
-    startMediaServer() // loopback HTTP for seekable local media (meeting videos)
-    // Heal a stale active-model.json whose model gained a vision projector after it was
-    // activated (e.g. Gemma 4 E2B) — turns vision on at launch if the projector is now
-    // on disk, without waiting for a re-activate.
-    void import('./models-manager').then((m) => m.reconcileActiveModelProjector()).catch(() => {})
-    ipcMain.handle('media:url', (_e, absPath: string) => mediaUrlFor(absPath))
-    // (clipboard is now a pro feature — setupClipboard runs in pro's activateMain)
-    // Pro features (capture, CRM, meetings, connectors, secretary, proactive,
-    // skills engine, console, tray) register their own IPC + intervals/capture loop
-    // here. No-op in the free build (the pro submodule is absent → stub).
-    void loadProFeaturesMain().catch((e) => console.error('[pro] load failed', e))
-    // Demo seeder for testing: OFFGRID_SEED=1 seeds once; OFFGRID_SEED=force re-seeds.
-    if (process.env.OFFGRID_SEED) {
-      void import('./dev-seed')
-        .then((m) => m.seedDemo(process.env.OFFGRID_SEED === 'force'))
-        .catch((e) => console.error('[seed]', e))
-    }
-    console.log('IPC Handlers Registered.')
-  } catch (e) {
-    console.error('FATAL: IPC Setup failed', e)
-  }
-
-  // 3. Initialize LLM (Async)
-  // We don't await this to avoid blocking window creation
-  import('./llm').then(({ llm }) => {
-    // Register the chat engine through the shared residency seam (runtime-manager),
-    // exactly like every other engine — the queue evicts it before a competing
-    // heavy job and re-warms it mode-aware (resident = reload; on-demand = release
-    // the pause block so it lazily respawns on next use, freeing RAM meanwhile).
-    registerRuntime(llm.runtime)
-    // Apply persisted queue settings (defaults: enabled, tier-1 coexists) — the
-    // keys + apply live in modality-queue/config so the settings UI shares them.
-    applyQueueConfig(modalityQueue, readQueueConfig(getSetting))
-    llm.init().catch((err) => console.error('Failed to init LLM:', err))
+  installIpcDiagnostics(ipcMain)
+  applicationShutdown.register({
+    name: 'startup:status-ipc',
+    shutdown: registerStartupStatusIpc()
   })
-  // Every other engine joins the SAME residency seam (runtime-manager), lazily so
-  // module load never blocks window creation. Registration only stores hooks — it
-  // doesn't spawn anything until the engine is actually used.
-  import('./tts').then(({ ttsRuntime }) => registerRuntime(ttsRuntime)).catch(() => {})
-  import('./imagegen').then(({ imageRuntime }) => registerRuntime(imageRuntime)).catch(() => {})
-  import('./transcription/select')
-    .then(({ sttRuntime }) => registerRuntime(sttRuntime))
-    .catch(() => {})
+
+  // The cached entitlement is the only asynchronous decision that must precede the shell. It is
+  // local and fail-closed: if it misses the bound, Pro stays unavailable until the provider lands.
+  await runStartupStage({
+    name: 'pro.entitlement.load-cached',
+    deadlineMs: 5_000,
+    required: true,
+    lateEffect: 'keep',
+    run: () => loadProEntitlementProvider()
+  })
+  initLicensing()
+  setupLicenseIpc()
+  const entitlementRefresh = setInterval(() => {
+    refreshCachedProEntitlement()
+    void revalidateProEntitlement('foreground')
+  }, PERSONAL_MESH_ENTITLEMENT_REVALIDATION_INTERVAL_MS)
+  entitlementRefresh.unref()
+  applicationShutdown.register({
+    name: 'pro:entitlement-refresh',
+    shutdown: () => clearInterval(entitlementRefresh)
+  })
+
+  await runStartupStage({
+    name: 'core.ipc',
+    deadlineMs: 10_000,
+    required: true,
+    lateEffect: 'guard',
+    run: ({ commit }) =>
+      commit('core.ipc.handlers', () => {
+        setupIPC()
+        setupRagIPC()
+        setupMcpIpc()
+        registerNativeActionTools(registerToolExtension)
+        setupDesktopBackupIPC()
+        ipcMain.handle('media:url', (_event, absPath: string) => mediaUrlFor(absPath))
+      })
+  })
+
+  // These registrations are independent. They load together, and each failure remains isolated.
+  await runIndependentStartupStages([
+    {
+      name: 'actions.ipc',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./actions/actions-ipc').then((module) =>
+          commit('actions.ipc.handlers', module.registerActionsIpc)
+        )
+    },
+    {
+      name: 'browser.view.ipc',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./browser/browser-host').then((module) =>
+          commit('browser.view.ipc.handlers', module.registerBrowserViewIpc)
+        )
+    },
+    {
+      name: 'vision.ipc',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./vision/vision-controller').then((module) =>
+          commit('vision.ipc.handlers', module.registerVisionIpc)
+        )
+    },
+    {
+      name: 'vision.supervisor-window',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./vision/supervisor-window').then((module) =>
+          commit('vision.supervisor-window.handlers', module.registerSupervisorWindowIpc)
+        )
+    },
+    {
+      name: 'tasks.history.ipc',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./tasks/task-history-ipc').then((module) =>
+          commit('tasks.history.ipc.handlers', module.registerTaskHistoryIpc)
+        )
+    }
+  ])
 
   createWindow()
 
-  // Update IPC is always registered (the renderer queries staged-version on startup
-  // in every build); the auto-download engine runs production-only (dev has no feed).
-  import('./updater')
-    .then((m) => {
-      m.registerUpdateIpc()
-      if (!is.dev) m.startAutoUpdates()
-    })
-    .catch((e) => console.error('[update] init', e))
+  // Network checks, model work, and optional services now run beside the visible shell.
+  void runIndependentStartupStages([
+    {
+      name: 'pro.entitlement.revalidate',
+      deadlineMs: 30_000,
+      lateEffect: 'keep',
+      run: () => revalidateProEntitlement('launch')
+    },
+    {
+      name: 'models.gateway.start',
+      deadlineMs: 30_000,
+      lateEffect: 'keep',
+      run: () => startModelServer()
+    },
+    {
+      name: 'media.server.start',
+      deadlineMs: 10_000,
+      lateEffect: 'keep',
+      run: () => startMediaServer()
+    },
+    {
+      name: 'models.text.prepare',
+      deadlineMs: 180_000,
+      lateEffect: 'keep',
+      run: async () => {
+        const { llm } = await import('./llm')
+        registerRuntime(llm.runtime)
+        applyQueueConfig(modalityQueue, readQueueConfig(getSetting))
+        if (llm.modelsExist()) await llm.init()
+      }
+    },
+    {
+      name: 'modalities.runtime.register',
+      deadlineMs: 30_000,
+      lateEffect: 'guard',
+      run: async ({ commit }) => {
+        const [{ ttsRuntime }, { imageRuntime }, { sttRuntime }] = await Promise.all([
+          import('./tts'),
+          import('./imagegen'),
+          import('./transcription/select')
+        ])
+        commit('modalities.runtime.registrations', () => {
+          registerRuntime(ttsRuntime)
+          registerRuntime(imageRuntime)
+          registerRuntime(sttRuntime)
+        })
+      }
+    },
+    {
+      name: 'models.projector.reconcile',
+      deadlineMs: 15_000,
+      lateEffect: 'keep',
+      run: () => import('./models-manager').then((module) => module.reconcileActiveModelProjector())
+    },
+    {
+      name: 'pro.features.load',
+      deadlineMs: 30_000,
+      lateEffect: 'keep',
+      run: () => loadProFeaturesMain()
+    },
+    {
+      name: 'updater.ipc',
+      deadlineMs: 15_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./updater').then((module) =>
+          commit('updater.ipc.handlers', () => {
+            module.registerUpdateIpc()
+            if (!is.dev) module.startAutoUpdates()
+          })
+        )
+    }
+  ])
+
+  // Demo seeding already runs beside the shell. Keep its existing persistence semantics instead of
+  // pretending an in-progress database write can be cancelled by a timer.
+  if (process.env.OFFGRID_SEED) {
+    void import('./dev-seed')
+      .then((module) => module.seedDemo(process.env.OFFGRID_SEED === 'force'))
+      .catch((error) => console.error('[seed]', error))
+  }
 
   app.on('activate', function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()

--- a/src/main/media-server.ts
+++ b/src/main/media-server.ts
@@ -195,13 +195,13 @@ function serveFile(req: http.IncomingMessage, res: http.ServerResponse, filePath
   rs.pipe(res)
 }
 
-/** Start the loopback media server (idempotent). Call after app is ready. */
-export function startMediaServer(): void {
+/** Start the loopback media server (idempotent). Resolves only after the socket is ready. */
+export function startMediaServer(): Promise<void> {
   productionServer ??= new LoopbackMediaServer({
     roots: localMediaRoots(app.getPath('userData'), resourceDirs()),
     port: MEDIA_PORT
   })
-  void productionServer.start().catch((error) => console.error('[media-server]', error))
+  return productionServer.start()
 }
 
 /** Build a loopback URL only after the production socket is ready. */

--- a/src/main/startup-ipc.ts
+++ b/src/main/startup-ipc.ts
@@ -1,0 +1,21 @@
+import { BrowserWindow, ipcMain } from 'electron'
+import { startupProjection } from './startup-projection'
+
+const STARTUP_STATUS_CHANNEL = 'app:startup-status'
+const STARTUP_STATUS_CHANGED_CHANNEL = 'app:startup-status-changed'
+
+export function registerStartupStatusIpc(): () => void {
+  ipcMain.handle(STARTUP_STATUS_CHANNEL, () => startupProjection.snapshot())
+  const unsubscribe = startupProjection.subscribe((snapshot) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send(STARTUP_STATUS_CHANGED_CHANNEL, snapshot)
+      }
+    }
+  })
+
+  return () => {
+    unsubscribe()
+    ipcMain.removeHandler(STARTUP_STATUS_CHANNEL)
+  }
+}

--- a/src/main/startup-projection.ts
+++ b/src/main/startup-projection.ts
@@ -1,0 +1,64 @@
+import type {
+  StartupPhase,
+  StartupSnapshot,
+  StartupStageSnapshot
+} from '../shared/startup-contract'
+
+export interface StartupProjection {
+  snapshot(): StartupSnapshot
+  subscribe(listener: (snapshot: StartupSnapshot) => void): () => void
+  stageStarted(stage: { readonly name: string; readonly required: boolean }): void
+  stageSettled(stage: StartupStageSnapshot): void
+}
+
+function phaseFor(stages: readonly StartupStageSnapshot[]): StartupPhase {
+  const failed = (stage: StartupStageSnapshot): boolean =>
+    stage.status === 'failed' || stage.status === 'timeout'
+
+  if (stages.some((stage) => stage.required && failed(stage))) return 'failed'
+  if (stages.some((stage) => stage.status === 'running')) return 'pending'
+  if (stages.some((stage) => failed(stage) || stage.status === 'late')) return 'degraded'
+  return stages.length > 0 ? 'ready' : 'pending'
+}
+
+export function createStartupProjection(): StartupProjection {
+  const stages = new Map<string, StartupStageSnapshot>()
+  const listeners = new Set<(snapshot: StartupSnapshot) => void>()
+  let revision = 0
+  let current: StartupSnapshot = {
+    revision,
+    phase: 'pending',
+    running: [],
+    stages: []
+  }
+
+  const publish = (): void => {
+    const reports = [...stages.values()]
+    revision += 1
+    current = {
+      revision,
+      phase: phaseFor(reports),
+      running: reports.filter((stage) => stage.status === 'running').map((stage) => stage.name),
+      stages: reports
+    }
+    for (const listener of listeners) listener(current)
+  }
+
+  return {
+    snapshot: () => current,
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    stageStarted: ({ name, required }) => {
+      stages.set(name, { name, status: 'running', required })
+      publish()
+    },
+    stageSettled: (stage) => {
+      stages.set(stage.name, stage)
+      publish()
+    }
+  }
+}
+
+export const startupProjection = createStartupProjection()

--- a/src/main/startup-stages.ts
+++ b/src/main/startup-stages.ts
@@ -1,0 +1,176 @@
+import { writeDiagnosticLog } from './diagnostics-log'
+import { startupProjection } from './startup-projection'
+
+export type StartupStageResult<T> =
+  | { readonly ok: true; readonly value: T; readonly durationMs: number }
+  | {
+      readonly ok: false
+      readonly reason: 'failed' | 'timeout'
+      readonly error: string
+      readonly durationMs: number
+    }
+
+export interface StartupStageContext {
+  readonly signal: AbortSignal
+  isOwner(): boolean
+  commit<R>(label: string, apply: () => R): R | undefined
+}
+
+interface StartupStageBase<T> {
+  readonly name: string
+  readonly deadlineMs: number
+  readonly required?: boolean
+  readonly run: (context: StartupStageContext) => Promise<T> | T
+}
+
+export type StartupStage<T> = StartupStageBase<T> &
+  (
+    | { readonly lateEffect: 'keep' }
+    | {
+        readonly lateEffect: 'guard'
+        readonly run: (context: StartupStageContext) => Promise<T> | T
+      }
+  )
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function settleFailure<T>(input: {
+  readonly stage: StartupStage<T>
+  readonly reason: 'failed' | 'timeout'
+  readonly error: string
+  readonly durationMs: number
+}): StartupStageResult<T> {
+  const { stage, reason, error, durationMs } = input
+  writeDiagnosticLog(
+    'startup',
+    reason === 'timeout' ? 'stage.timeout' : 'stage.failed',
+    { stage: stage.name, durationMs, error },
+    'error'
+  )
+  startupProjection.stageSettled({
+    name: stage.name,
+    status: reason,
+    required: stage.required === true,
+    durationMs,
+    error
+  })
+  return { ok: false, reason, error, durationMs }
+}
+
+export async function runStartupStage<T>(stage: StartupStage<T>): Promise<StartupStageResult<T>> {
+  const startedAt = Date.now()
+  const required = stage.required === true
+  const controller = new AbortController()
+  let owned = true
+  let commitsApplied = 0
+  let commitsRefused = 0
+  let timer: NodeJS.Timeout | undefined
+
+  startupProjection.stageStarted({ name: stage.name, required })
+
+  const context: StartupStageContext = {
+    signal: controller.signal,
+    isOwner: () => owned,
+    commit: <R>(label: string, apply: () => R): R | undefined => {
+      if (owned) {
+        commitsApplied += 1
+        return apply()
+      }
+      commitsRefused += 1
+      writeDiagnosticLog(
+        'startup',
+        'stage.late-commit-refused',
+        { stage: stage.name, change: label },
+        'error'
+      )
+      return undefined
+    }
+  }
+
+  const work = Promise.resolve().then(() => stage.run(context))
+  const deadline = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => {
+      owned = false
+      controller.abort()
+      resolve('timeout')
+    }, stage.deadlineMs)
+    timer.unref()
+  })
+
+  try {
+    const outcome = await Promise.race([work.then((value) => ({ value }) as const), deadline])
+    const durationMs = Date.now() - startedAt
+    if (outcome === 'timeout') {
+      void work.then(
+        () => {
+          const lateDurationMs = Date.now() - startedAt
+          const kept = stage.lateEffect === 'keep'
+          const effect = kept ? 'kept' : commitsRefused > 0 ? 'guarded' : 'no-guarded-change'
+          writeDiagnosticLog(
+            'startup',
+            'stage.late-completion',
+            {
+              stage: stage.name,
+              durationMs: lateDurationMs,
+              effect,
+              commitsApplied,
+              commitsRefused
+            },
+            'warn'
+          )
+          if (kept) {
+            startupProjection.stageSettled({
+              name: stage.name,
+              status: 'late',
+              required,
+              durationMs: lateDurationMs,
+              error: `settled ${lateDurationMs - stage.deadlineMs}ms after its deadline`
+            })
+          }
+        },
+        (error: unknown) => {
+          writeDiagnosticLog(
+            'startup',
+            'stage.late-failure',
+            { stage: stage.name, durationMs: Date.now() - startedAt, error: describe(error) },
+            'error'
+          )
+        }
+      )
+      return settleFailure({
+        stage,
+        reason: 'timeout',
+        error: `exceeded ${stage.deadlineMs}ms`,
+        durationMs
+      })
+    }
+
+    owned = false
+    writeDiagnosticLog('startup', 'stage.completed', { stage: stage.name, durationMs })
+    startupProjection.stageSettled({
+      name: stage.name,
+      status: 'completed',
+      required,
+      durationMs
+    })
+    return { ok: true, value: outcome.value, durationMs }
+  } catch (error) {
+    owned = false
+    return settleFailure({
+      stage,
+      reason: 'failed',
+      error: describe(error),
+      durationMs: Date.now() - startedAt
+    })
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+export function runIndependentStartupStages(
+  stages: readonly StartupStage<unknown>[]
+): Promise<readonly StartupStageResult<unknown>[]> {
+  return Promise.all(stages.map((stage) => runStartupStage(stage)))
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -27,6 +27,7 @@ import type {
 } from '../shared/browser-session'
 import type { TaskGuideInput } from '../shared/task-guidance'
 import type { RemoteVisionServerUpdate } from '../shared/remote-vision-server'
+import type { StartupSnapshot } from '../shared/startup-contract'
 import type { TaskRunSnapshot } from '../main/tasks/task-history-store'
 
 console.log('PRELOAD SCRIPT LOADED')
@@ -511,6 +512,13 @@ const offGridApi = {
     ): void => callback(data)
     ipcRenderer.on('model:download-progress', subscription)
     return unsubscribe('model:download-progress', subscription)
+  },
+
+  startupStatus: (): Promise<StartupSnapshot> => ipcRenderer.invoke('app:startup-status'),
+  onStartupStatusChanged: (callback: (snapshot: StartupSnapshot) => void) => {
+    const subscription = (_event: unknown, snapshot: StartupSnapshot): void => callback(snapshot)
+    ipcRenderer.on('app:startup-status-changed', subscription)
+    return unsubscribe('app:startup-status-changed', subscription)
   },
 
   // Setup + system health

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -67,6 +67,7 @@ import { navigateSearchHit } from './lib/search-navigation'
 import { internalTabPaletteScreens } from './lib/paletteScreens'
 import { getSlot, SLOTS } from './bootstrap/slotRegistry'
 import { SidebarNavigationMenu } from './components/navigation/SidebarNavigationMenu'
+import { StartupNotice } from './components/StartupNotice'
 import { CHAT_VIEW, setCurrentView } from './lib/current-view'
 import {
   OPEN_MODEL_SETTINGS_PANEL_EVENT,
@@ -1045,6 +1046,7 @@ function AppContent() {
 
   return (
     <div className="h-screen w-full overflow-hidden bg-neutral-950 relative">
+      <StartupNotice />
       <CommandPalette
         onOpenHit={handleOpenHit}
         onSeeAll={openSearch}

--- a/src/renderer/src/components/StartupNotice.tsx
+++ b/src/renderer/src/components/StartupNotice.tsx
@@ -1,0 +1,108 @@
+import { WarningCircle } from '@phosphor-icons/react'
+import { useCallback, useEffect, useState } from 'react'
+import type { StartupSnapshot } from '../../../shared/startup-contract'
+import { LoadingDots } from './ui/loading-dots'
+
+const STAGE_LABELS: Readonly<Record<string, string>> = {
+  'pro.entitlement.load-cached': 'Checking your license',
+  'core.ipc': 'Starting Off Grid AI Desktop',
+  'actions.ipc': 'Starting actions',
+  'browser.view.ipc': 'Starting Web Use',
+  'vision.ipc': 'Starting Computer Use',
+  'vision.supervisor-window': 'Starting Computer Use',
+  'tasks.history.ipc': 'Opening your tasks',
+  'pro.entitlement.revalidate': 'Confirming your license',
+  'models.gateway.start': 'Starting the local API',
+  'media.server.start': 'Preparing media playback',
+  'models.text.prepare': 'Loading your model',
+  'modalities.runtime.register': 'Preparing local models',
+  'models.projector.reconcile': 'Checking your models',
+  'pro.features.load': 'Starting Pro features',
+  'updater.ipc': 'Checking for updates'
+}
+
+function labelFor(stageName: string | undefined): string | undefined {
+  return stageName ? STAGE_LABELS[stageName] : undefined
+}
+
+function pendingText(snapshot: StartupSnapshot): string {
+  return labelFor(snapshot.running[0]) ?? 'Starting Off Grid AI Desktop'
+}
+
+function degradedText(snapshot: StartupSnapshot): string {
+  const failed = snapshot.stages.find(
+    (stage) => stage.status === 'failed' || stage.status === 'timeout'
+  )
+  const failedLabel = labelFor(failed?.name)
+  if (failedLabel) return `${failedLabel} did not finish. The rest of the app is ready.`
+
+  const late = snapshot.stages.find((stage) => stage.status === 'late')
+  const lateLabel = labelFor(late?.name)
+  return lateLabel
+    ? `${lateLabel} took longer than expected, but it is ready.`
+    : 'Part of the app took longer than expected, but it is ready.'
+}
+
+export function StartupNotice(): React.JSX.Element | null {
+  const [snapshot, setSnapshot] = useState<StartupSnapshot | null>(null)
+  const applySnapshot = useCallback((next: StartupSnapshot): void => {
+    setSnapshot((current) => (!current || next.revision >= current.revision ? next : current))
+  }, [])
+
+  useEffect(() => {
+    let mounted = true
+    const unsubscribe = window.api.onStartupStatusChanged((next) => {
+      if (mounted) applySnapshot(next)
+    })
+    void window.api
+      .startupStatus()
+      .then((next) => {
+        if (mounted) applySnapshot(next)
+      })
+      .catch(() => {})
+
+    return () => {
+      mounted = false
+      unsubscribe()
+    }
+  }, [applySnapshot])
+
+  if (!snapshot || snapshot.phase === 'ready') return null
+
+  if (snapshot.phase === 'failed') {
+    return (
+      <div
+        role="status"
+        aria-live="assertive"
+        className="pointer-events-none absolute inset-x-0 top-0 z-50 flex items-center justify-center gap-2 bg-red-950/90 px-4 py-1.5 font-mono text-[11px] text-red-200"
+      >
+        <WarningCircle size={13} weight="bold" aria-hidden />
+        <span>Off Grid AI Desktop could not finish startup. Restart the app.</span>
+      </div>
+    )
+  }
+
+  if (snapshot.phase === 'degraded') {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="pointer-events-none absolute inset-x-0 top-0 z-50 flex items-center justify-center gap-2 bg-amber-950/80 px-4 py-1.5 font-mono text-[11px] text-amber-200"
+      >
+        <WarningCircle size={13} aria-hidden />
+        <span>{degradedText(snapshot)}</span>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none absolute inset-x-0 top-0 z-50 flex items-center justify-center gap-2 bg-neutral-900/85 px-4 py-1.5 font-mono text-[11px] text-neutral-400"
+    >
+      <span>{pendingText(snapshot)}</span>
+      <LoadingDots size="small" />
+    </div>
+  )
+}

--- a/src/renderer/src/components/ui/loading-dots.tsx
+++ b/src/renderer/src/components/ui/loading-dots.tsx
@@ -8,11 +8,12 @@ interface LoadingDotsProps {
 /** One three-dot busy state for every Desktop surface. */
 export function LoadingDots({ size = 'medium', className = '' }: LoadingDotsProps): ReactElement {
   const dot = size === 'small' ? 'h-1 w-1' : 'h-1.5 w-1.5'
+  const animation = 'animate-bounce motion-reduce:animate-none'
   return (
     <span className={`inline-flex items-center gap-1 px-1 ${className}`} aria-hidden="true">
-      <span className={`${dot} animate-bounce rounded-full bg-green-500 [animation-delay:0ms]`} />
-      <span className={`${dot} animate-bounce rounded-full bg-green-500 [animation-delay:150ms]`} />
-      <span className={`${dot} animate-bounce rounded-full bg-green-500 [animation-delay:300ms]`} />
+      <span className={`${dot} ${animation} rounded-full bg-green-500 [animation-delay:0ms]`} />
+      <span className={`${dot} ${animation} rounded-full bg-green-500 [animation-delay:150ms]`} />
+      <span className={`${dot} ${animation} rounded-full bg-green-500 [animation-delay:300ms]`} />
     </span>
   )
 }

--- a/src/shared/startup-contract.ts
+++ b/src/shared/startup-contract.ts
@@ -1,0 +1,18 @@
+export type StartupPhase = 'pending' | 'ready' | 'degraded' | 'failed'
+
+export type StartupStageStatus = 'running' | 'completed' | 'failed' | 'timeout' | 'late'
+
+export interface StartupStageSnapshot {
+  readonly name: string
+  readonly status: StartupStageStatus
+  readonly required: boolean
+  readonly durationMs?: number
+  readonly error?: string
+}
+
+export interface StartupSnapshot {
+  readonly revision: number
+  readonly phase: StartupPhase
+  readonly running: readonly string[]
+  readonly stages: readonly StartupStageSnapshot[]
+}


### PR DESCRIPTION
## Outcome

Desktop opens the usable shell before optional startup work completes. Startup state remains explicit and visible.

## Scope

- Restore staged Desktop startup.
- Keep optional services outside the shell-critical path.
- Add startup projection and stage coverage.

## Evidence

- Six focused Desktop startup tests pass.
- An isolated development launch reached a ready state for all startup stages.
- Focused lint and diff checks pass.

## Open gates

- Behavioral UI and visual verification remain blocked by existing Shared and Desktop Pro interface drift.
- The production and packaged build gates remain open.

This PR is draft until the required gates pass.

## Stack

Base: release/computer_use
Next: codex/f2-app-restart