### PR TITLE
fix(startup): establish profile before storage owners load

### DIFF
--- a/e2e/app-restart-profile.spec.ts
+++ b/e2e/app-restart-profile.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type ElectronApplication } from '@playwright/test'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import electronExecutable from 'electron'
+import { launchOffGrid } from './helpers/launch'
+
+let app: ElectronApplication | undefined
+let profile: string
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(() => {
+  profile = fs.mkdtempSync(path.join(os.tmpdir(), 'offgrid-app-restart-'))
+})
+
+test.afterEach(async () => {
+  await app?.close().catch(() => undefined)
+  app = undefined
+})
+
+test.afterAll(() => {
+  fs.rmSync(profile, { recursive: true, force: true })
+})
+
+async function launchAndReadPaths(): Promise<{ userData: string; models: string }> {
+  app = await launchOffGrid({
+    env: {
+      ...process.env,
+      OFFGRID_USER_DATA: profile,
+      OFFGRID_PRO: '0',
+      OFFGRID_E2E_HEADLESS: '1',
+      OFFGRID_E2E_ISOLATED_INSTANCE: '1',
+      NODE_ENV: 'production'
+    }
+  })
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  return {
+    userData: await app.evaluate(({ app: electronApp }) => electronApp.getPath('userData')),
+    models: await page.evaluate(async () => (await window.api.checkModelStatus()).modelsDir)
+  }
+}
+
+test('keeps application and model storage in one selected profile across restart', async () => {
+  const first = await launchAndReadPaths()
+  expect(first).toEqual({ userData: profile, models: path.join(profile, 'models') })
+  expect(fs.existsSync(path.join(profile, 'memories.db'))).toBe(true)
+
+  await app?.close()
+  app = undefined
+
+  const second = await launchAndReadPaths()
+  expect(second).toEqual(first)
+  expect(fs.existsSync(path.join(profile, 'memories.db'))).toBe(true)
+})
+
+test('exits when an explicit profile cannot be established', async () => {
+  const invalidProfile = path.join(profile, 'not-a-directory')
+  fs.writeFileSync(invalidProfile, 'occupied by a file')
+  const environment = {
+    ...process.env,
+    OFFGRID_USER_DATA: invalidProfile,
+    OFFGRID_PRO: '0',
+    OFFGRID_E2E_HEADLESS: '1',
+    OFFGRID_E2E_ISOLATED_INSTANCE: '1',
+    NODE_ENV: 'production'
+  }
+  delete environment.ELECTRON_RUN_AS_NODE
+
+  const child = spawn(
+    electronExecutable as unknown as string,
+    [path.resolve('.'), '--server-only'],
+    {
+      cwd: path.resolve('.'),
+      env: environment,
+      stdio: ['ignore', 'ignore', 'pipe']
+    }
+  )
+  let stderr = ''
+  child.stderr?.setEncoding('utf8')
+  child.stderr?.on('data', (chunk: string) => {
+    stderr += chunk
+  })
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill()
+      reject(new Error('Electron continued after the explicit profile failed'))
+    }, 15_000)
+    child.once('exit', (code) => {
+      clearTimeout(timeout)
+      resolve(code)
+    })
+  })
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain('[userData] initialization failed')
+})

--- a/src/main/__tests__/product-identity.test.ts
+++ b/src/main/__tests__/product-identity.test.ts
@@ -64,12 +64,21 @@ describe('installed product identity', () => {
     expect(localBuild).not.toMatch(/-c\.productName="Off Grid AI(?: Pro)?"/)
 
     const main = fs.readFileSync(path.join(root, 'src/main/index.ts'), 'utf8')
-    const bootstrap = main.indexOf('beginProductIdentityBootstrap(app, process.platform)')
+    const userDataBootstrap = fs.readFileSync(
+      path.join(root, 'src/main/bootstrap/user-data.ts'),
+      'utf8'
+    )
+    const firstImport = main.indexOf(
+      "import { restoreCanonicalProductName } from './bootstrap/user-data'"
+    )
     const ready = main.indexOf('app.whenReady().then')
     const restore = main.indexOf('restoreCanonicalProductName()', ready)
     const serverOnly = main.indexOf("process.argv.includes('--server-only')", ready)
-    expect(bootstrap).toBeGreaterThan(-1)
-    expect(bootstrap).toBeLessThan(ready)
+    expect(firstImport).toBe(0)
+    expect(userDataBootstrap).toContain('beginProductIdentityBootstrap(app, process.platform)')
+    expect(userDataBootstrap).toContain("app.setPath('userData', process.env.OFFGRID_USER_DATA)")
+    expect(userDataBootstrap).toContain('app.exit(1)')
+    expect(userDataBootstrap).toContain('throw error')
     expect(restore).toBeGreaterThan(ready)
     expect(restore).toBeLessThan(serverOnly)
     expect(main).toContain('applicationName: PRODUCT_NAME')

--- a/src/main/bootstrap/user-data.ts
+++ b/src/main/bootstrap/user-data.ts
@@ -1,0 +1,59 @@
+import { app } from 'electron'
+import fs from 'node:fs'
+import { join } from 'node:path'
+import { beginProductIdentityBootstrap } from '../product-identity-lifecycle'
+import { repairMissingDefaultKeychainAtBootstrap } from '../secure-storage-bootstrap'
+
+let restoreProductName: (() => void) | null = null
+
+function initializeUserData(): void {
+  const security = repairMissingDefaultKeychainAtBootstrap(process.platform, app.isPackaged)
+  if (security?.status === 'repaired') console.warn(`[secure-storage] ${security.detail}`)
+  else if (security && security.status !== 'healthy') {
+    console.error(`[secure-storage] ${security.detail}`)
+  }
+
+  restoreProductName = beginProductIdentityBootstrap(app, process.platform)
+
+  if (process.env.OFFGRID_USER_DATA) {
+    fs.mkdirSync(process.env.OFFGRID_USER_DATA, { recursive: true })
+    app.setPath('userData', process.env.OFFGRID_USER_DATA)
+    console.log('[userData] override path:', process.env.OFFGRID_USER_DATA)
+    return
+  }
+
+  const appData = app.getPath('appData')
+  const canonical = join(appData, 'Off Grid AI Desktop')
+  fs.mkdirSync(canonical, { recursive: true })
+  const move = (fromDir: string, name: string): void => {
+    try {
+      const source = join(fromDir, name)
+      const destination = join(canonical, name)
+      if (fs.existsSync(source) && !fs.existsSync(destination)) {
+        fs.renameSync(source, destination)
+      }
+    } catch (error) {
+      console.warn('[userData] migrate skip', name, error)
+    }
+  }
+  move(join(appData, 'My Memories'), 'models')
+  move(join(appData, 'my-memories'), 'models')
+  move(join(appData, 'my-memories'), 'memories.db')
+  move(join(appData, 'My Memories'), 'memories.db')
+  app.setPath('userData', canonical)
+  console.log('[userData] canonical path:', canonical)
+}
+
+try {
+  initializeUserData()
+} catch (error) {
+  console.error('[userData] initialization failed', error)
+  app.exit(1)
+  throw error
+}
+
+/** Restore the visible product name after Electron finishes its secure-storage lookup. */
+export function restoreCanonicalProductName(): void {
+  if (!restoreProductName) throw new Error('User data was not initialized.')
+  restoreProductName()
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,6 @@
+import { restoreCanonicalProductName } from './bootstrap/user-data'
 import { app, shell, BrowserWindow, protocol, session, desktopCapturer, screen } from 'electron'
-import { join } from 'path'
 import { tmpdir } from 'os'
-import fs from 'fs'
 
 // Custom scheme to serve local capture screenshots to the renderer (file:// is
 // blocked there). Registered before app 'ready'; handled after.
@@ -58,8 +57,6 @@ import { PRODUCT_NAME } from '../shared/product-identity'
 import { installMediaPermissionHandler } from './media-permission'
 import { localMediaRoots } from './media-roots'
 import { resourceDirs } from './runtime-env'
-import { beginProductIdentityBootstrap } from './product-identity-lifecycle'
-import { repairMissingDefaultKeychainAtBootstrap } from './secure-storage-bootstrap'
 import {
   installDiagnosticConsoleCapture,
   installIpcDiagnostics,
@@ -79,60 +76,6 @@ import { shutdownModelDownloads } from './models/download-queue'
 // Before anything logs: a broken stdout/stderr pipe (parent/e2e-harness exited, closed pipe)
 // must never crash main via an uncaught EPIPE. See stream-guards.ts.
 guardConsoleStreams([process.stdout, process.stderr])
-
-// Electron asks macOS for its safeStorage password during early bootstrap. Repair
-// the one safe, known-bad state before that lookup can trigger SecurityAgent's
-// generic "Keychain Not Found" dialog. This never creates or resets a Keychain.
-const secureStorageBootstrap = repairMissingDefaultKeychainAtBootstrap(
-  process.platform,
-  app.isPackaged
-)
-if (secureStorageBootstrap?.status === 'repaired') {
-  console.warn(`[secure-storage] ${secureStorageBootstrap.detail}`)
-} else if (secureStorageBootstrap && secureStorageBootstrap.status !== 'healthy') {
-  console.error(`[secure-storage] ${secureStorageBootstrap.detail}`)
-}
-
-// Pin one canonical userData dir ("Off Grid AI Desktop") regardless of package
-// name, and migrate data from the legacy split dirs ("My Memories" had the
-// models, "my-memories" had the DB) so nothing is lost / re-downloaded. Must run
-// before app 'ready' and before any getPath('userData') usage.
-// Preserve the Keychain namespace used by every existing install during Electron's
-// early safeStorage bootstrap. The returned callback restores the canonical visible
-// product name at the beginning of the ready phase.
-const restoreCanonicalProductName = beginProductIdentityBootstrap(app, process.platform)
-;(function unifyUserDataPath(): void {
-  try {
-    // Test/CI seam: let a harness isolate userData (e.g. screenshot capture of
-    // a fresh, pre-onboarding profile). Harmless in production (unset).
-    if (process.env.OFFGRID_USER_DATA) {
-      fs.mkdirSync(process.env.OFFGRID_USER_DATA, { recursive: true })
-      app.setPath('userData', process.env.OFFGRID_USER_DATA)
-      console.log('[userData] override path:', process.env.OFFGRID_USER_DATA)
-      return
-    }
-    const appData = app.getPath('appData')
-    const canonical = join(appData, 'Off Grid AI Desktop')
-    fs.mkdirSync(canonical, { recursive: true })
-    const move = (fromDir: string, name: string): void => {
-      try {
-        const src = join(fromDir, name)
-        const dst = join(canonical, name)
-        if (fs.existsSync(src) && !fs.existsSync(dst)) fs.renameSync(src, dst)
-      } catch (e) {
-        console.warn('[userData] migrate skip', name, e)
-      }
-    }
-    move(join(appData, 'My Memories'), 'models')
-    move(join(appData, 'my-memories'), 'models')
-    move(join(appData, 'my-memories'), 'memories.db')
-    move(join(appData, 'My Memories'), 'memories.db')
-    app.setPath('userData', canonical)
-    console.log('[userData] canonical path:', canonical)
-  } catch (e) {
-    console.error('[userData] unify failed', e)
-  }
-})()
 
 installDiagnosticConsoleCapture()
 writeDiagnosticLog('app', 'bootstrap.started', {


### PR DESCRIPTION
## Outcome

Desktop restart uses the selected profile before any storage owner can capture a path. An invalid explicit override fails closed.

## Scope

- Establish the user-data profile before storage-owning imports.
- Preserve the existing legacy user-data behavior.
- Add restart and profile-isolation coverage.

## Evidence

- Desktop Playwright restart tests pass: 2 of 2.
- The focused product-identity test passes.
- Focused lint passes.

## Open gates

- The renderer production build is blocked by existing Shared and Desktop Pro interface drift, including PERSONAL_MESH_DEVICE_CAP.
- Live visual verification remains open.

This PR is draft until the required gates pass.

## Stack

Base: codex/f1-app-launch