### PR TITLE
fix(projects): stop deletion when cleanup fails

### DIFF
--- a/src/main/__tests__/rag-ipc-project-create.dbtest.ts
+++ b/src/main/__tests__/rag-ipc-project-create.dbtest.ts
@@ -20,6 +20,7 @@ vi.mock('electron', () => ({
 }))
 
 import { setupRagIPC } from '../rag-ipc'
+import { getDB } from '../database'
 import { listProjects } from '../rag/store'
 
 afterAll(() => {
@@ -80,5 +81,32 @@ describe('project IPC persistence', () => {
       icon: 'rocket',
       includeMemory: false
     })
+  })
+
+  it('returns a refusal and preserves the project when the database transaction fails', () => {
+    setupRagIPC()
+    const create = handlers.get('projects:create')
+    const remove = handlers.get('projects:delete')
+    expect(create).toBeTypeOf('function')
+    expect(remove).toBeTypeOf('function')
+
+    const projectId = create!(undefined, { name: 'Protected project' }) as string
+    getDB().exec(`
+      CREATE TRIGGER refuse_project_delete
+      BEFORE DELETE ON projects
+      BEGIN
+        SELECT RAISE(ABORT, 'knowledge cleanup did not finish');
+      END;
+    `)
+
+    expect(remove!(undefined, projectId)).toEqual({
+      ok: false,
+      reason: 'knowledge cleanup did not finish'
+    })
+    expect(listProjects()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: projectId, name: 'Protected project' })
+      ])
+    )
   })
 })

--- a/src/main/rag-ipc.ts
+++ b/src/main/rag-ipc.ts
@@ -6,6 +6,7 @@ import fs from 'fs'
 import { randomUUID } from 'node:crypto'
 import { ragService, listProjects, createProject, updateProject, deleteProject } from './rag'
 import { uploadPickerExtensions } from './files-classify'
+import { projectDeleteFailure, type ProjectDeleteOutcome } from '../shared/project-delete-outcome'
 
 // Built from the router's classify sets (files-classify) so the picker allowlist
 // and the processor can never drift: it used to hardcode a subset that omitted
@@ -29,7 +30,16 @@ export function setupRagIPC(): void {
     updateProject(id, patch)
   })
 
-  ipcMain.handle('projects:delete', (_e, id: string) => deleteProject(id))
+  ipcMain.handle('projects:delete', (_e, id: string): ProjectDeleteOutcome => {
+    try {
+      // The RAG store owns one transaction for the project, its documents, and its chat links.
+      // Report that transaction's result before the renderer drops its local projection.
+      deleteProject(id)
+      return { ok: true }
+    } catch (error) {
+      return projectDeleteFailure(error)
+    }
+  })
 
   // --- Knowledge base (documents) ------------------------------------------
   ipcMain.handle('projects:list-documents', (_e, projectId: string) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -28,6 +28,7 @@ import type {
 import type { TaskGuideInput } from '../shared/task-guidance'
 import type { RemoteVisionServerUpdate } from '../shared/remote-vision-server'
 import type { StartupSnapshot } from '../shared/startup-contract'
+import type { ProjectDeleteOutcome } from '../shared/project-delete-outcome'
 import type { TaskRunSnapshot } from '../main/tasks/task-history-store'
 
 console.log('PRELOAD SCRIPT LOADED')
@@ -771,7 +772,8 @@ const offGridApi = {
   }) => ipcRenderer.invoke('projects:create', p),
   updateProject: (id: string, patch: Record<string, unknown>) =>
     ipcRenderer.invoke('projects:update', id, patch),
-  deleteProject: (id: string) => ipcRenderer.invoke('projects:delete', id),
+  deleteProject: (id: string) =>
+    ipcRenderer.invoke('projects:delete', id) as Promise<ProjectDeleteOutcome>,
   listProjectDocuments: (projectId: string) =>
     ipcRenderer.invoke('projects:list-documents', projectId),
   addProjectDocuments: (projectId: string) =>

--- a/src/renderer/src/components/ProjectsScreen.tsx
+++ b/src/renderer/src/components/ProjectsScreen.tsx
@@ -19,6 +19,10 @@ import { ArtifactCanvas, type Artifact } from './ArtifactCanvas'
 import { artifactKindLabel } from '@renderer/lib/artifact-labels'
 import { timeAgo } from '@renderer/lib/time'
 import { useRendererEntitlement } from '@renderer/bootstrap/useRendererEntitlement'
+import {
+  PROJECT_DELETE_FALLBACK_REASON,
+  type ProjectDeleteOutcome
+} from '../../../shared/project-delete-outcome'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const api = (window as any).api
@@ -133,6 +137,7 @@ export function ProjectsScreen({
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
   const [view, setView] = useState<'chat' | 'artifacts' | 'config'>('chat')
+  const [deleteFailure, setDeleteFailure] = useState('')
 
   const refreshProjects = useCallback(async () => {
     const list = (await api.listProjects?.()) ?? []
@@ -176,7 +181,12 @@ export function ProjectsScreen({
     ) {
       return
     }
-    await api.deleteProject?.(id)
+    setDeleteFailure('')
+    const outcome = (await api.deleteProject?.(id)) as ProjectDeleteOutcome | undefined
+    if (!outcome?.ok) {
+      setDeleteFailure(outcome?.reason || PROJECT_DELETE_FALLBACK_REASON)
+      return
+    }
     selectProject(null)
     await refreshProjects()
   }
@@ -195,6 +205,11 @@ export function ProjectsScreen({
             <IconPlus className="h-4 w-4" />
           </button>
         </div>
+        {deleteFailure ? (
+          <p role="alert" className="mx-4 mb-2 text-[11px] text-red-400">
+            {deleteFailure}
+          </p>
+        ) : null}
         <div className="flex-1 overflow-y-auto px-2">
           {creating && (
             <input

--- a/src/renderer/src/components/__tests__/ProjectsScreen.delete-refusal.integration.test.tsx
+++ b/src/renderer/src/components/__tests__/ProjectsScreen.delete-refusal.integration.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RendererEntitlementProvider } from '../../bootstrap/RendererEntitlementProvider'
+import { installAppBoundary } from '../../__tests__/harness/app-boundary'
+
+const project = {
+  id: 'protected-project',
+  name: 'Protected project',
+  description: '',
+  systemPrompt: '',
+  includeMemory: false,
+  updatedAt: '2026-09-11T00:00:00.000Z'
+}
+
+describe('<ProjectsScreen/> delete refusal', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the selected project and shows the cleanup reason', async () => {
+    installAppBoundary({
+      listProjects: async () => [project],
+      deleteProject: async () => ({
+        ok: false,
+        reason: 'Knowledge cleanup did not finish.'
+      })
+    })
+    const user = userEvent.setup()
+    const { ProjectsScreen } = await import('../ProjectsScreen')
+
+    render(
+      <RendererEntitlementProvider>
+        <ProjectsScreen onOpenChat={() => undefined} />
+      </RendererEntitlementProvider>
+    )
+
+    expect((await screen.findAllByText(project.name)).length).toBeGreaterThan(0)
+    await user.click(screen.getByRole('button', { name: /knowledge & settings/i }))
+    await user.click(screen.getByTitle('Delete project'))
+
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Knowledge cleanup did not finish.'
+    )
+    await waitFor(() => expect(screen.getAllByText(project.name).length).toBeGreaterThan(0))
+  })
+})

--- a/src/shared/project-delete-outcome.ts
+++ b/src/shared/project-delete-outcome.ts
@@ -1,0 +1,13 @@
+export type ProjectDeleteOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string }
+
+export const PROJECT_DELETE_FALLBACK_REASON = 'This project could not be deleted.'
+
+export function projectDeleteFailure(error: unknown): ProjectDeleteOutcome {
+  const reason = error instanceof Error ? error.message.trim() : String(error).trim()
+  return {
+    ok: false,
+    reason: reason || PROJECT_DELETE_FALLBACK_REASON
+  }
+}


### PR DESCRIPTION
## Recovered outcome

A project stays available when its knowledge cleanup fails. The Projects screen now explains the refusal instead of appearing to ignore the delete action.

## Scope

- Return one typed delete outcome from the Desktop project IPC boundary.
- Keep the selected project when the SQLite cleanup transaction fails.
- Show the returned reason in the existing Projects surface.
- Add a real SQLite refusal check and a rendered failure-state integration check.

## Passed checks

- Live development flow: created and deleted `F3 Live Cleanup` through the rendered Projects surface in an isolated profile.
- `npm run test:db -- src/main/__tests__/rag-ipc-project-create.dbtest.ts`: 3 passed.
- Rendered Projects refusal integration: 1 passed.
- Focused ESLint: 0 errors; 6 existing preload warnings.
- Diff and formatting checks passed.
- CodeRabbit passed or skipped review because this PR is draft.

## Open gates

- Desktop node and web typechecks remain blocked by existing Shared/model/RAG interface drift in `models-manager.ts`, `rag/index.ts`, `rag/store.ts`, and `setup.ts`.
- Hosted CI failed at the same core typecheck gate and did not run later checks.
- The production and packaged Desktop builds were not run because the typecheck gate is open.
- The live refusal-state run did not finish because the existing startup/navigation surface was unstable; the real SQLite and rendered integration checks passed separately.
- Visual inspection is open because this recovery task prohibits Computer Use.

This PR must remain draft while these required gates are open.