### PR TITLE
fix(tools): enforce shared execution policy

### DIFF
--- a/src/main/__tests__/tools-loop.dbtest.ts
+++ b/src/main/__tests__/tools-loop.dbtest.ts
@@ -523,6 +523,61 @@ describe('agentic tool loop — real toolChat + real LLMService over a fake llam
     }
   })
 
+  it('shows successful tool output when the final model turn is empty', async () => {
+    enqueueReactiveAfterEmptyPlan(
+      { toolCalls: [{ name: 'calculator', args: { expression: '2+2' } }] },
+      { content: '' }
+    )
+    const deltas: string[] = []
+
+    const result = await toolChat('what is 2+2', [], {
+      onDelta: (text, kind) => {
+        if (kind === 'content') deltas.push(text)
+      }
+    })
+
+    expect(result.answer).toBe('4')
+    expect(deltas.join('')).toBe('4')
+  })
+
+  it('bounds each tool result to the room left in the active model window', async () => {
+    const raw = 'x'.repeat(30_000)
+    const extension = {
+      id: 'large-result-ext',
+      schemas: () => [
+        {
+          type: 'function',
+          function: {
+            name: 'large_result',
+            description: 'Return a large result',
+            parameters: { type: 'object', properties: {} }
+          }
+        }
+      ],
+      canHandle: (name: string) => name === 'large_result',
+      execute: async () => raw
+    }
+    registerToolExtension(extension)
+    const service = llm as unknown as { ctxSize: number }
+    const previousContext = service.ctxSize
+    service.ctxSize = 2_048
+    try {
+      enqueueReactiveAfterEmptyPlan(
+        { toolCalls: [{ name: 'large_result', args: {} }] },
+        { content: 'Used the bounded result.' }
+      )
+
+      const result = await toolChat('read it', [], { connectors: true })
+
+      expect(result.toolCalls[0]!.result.length).toBeLessThan(raw.length)
+      expect(result.toolCalls[0]!.result).toMatch(/result truncated: showing the first 1000/)
+      expect(JSON.stringify(fake.requests[1])).not.toContain(raw)
+    } finally {
+      service.ctxSize = previousContext
+      unregisterToolExtension(extension.id, extension)
+    }
+  })
+
   it('rejects a non-arithmetic calculator expression (real guard branch)', async () => {
     enqueueReactiveAfterEmptyPlan(
       { toolCalls: [{ name: 'calculator', args: { expression: 'process.exit(1)' } }] },

--- a/src/main/tools.ts
+++ b/src/main/tools.ts
@@ -25,7 +25,14 @@ import {
 } from './proposal-deck/tool'
 import { proposalDeckSystemHint, proposalDeckService } from './proposal-deck/service'
 import { callHookAsync, HOOKS } from './bootstrap/hookRegistry'
-import { DEFAULT_MAX_TOOL_CALLS } from '../shared/llm-defaults'
+import {
+  boundToolResult,
+  callsWithinToolBudget,
+  finalResponseFromToolResults,
+  normalizeMaxToolCalls,
+  toolPromptChars,
+  toolResultCharBudget
+} from '@offgrid/models'
 
 // Per-tool enable/disable, persisted as a list of disabled tool names.
 function disabledSet(): Set<string> {
@@ -672,6 +679,7 @@ export async function toolChat(
     { role: 'user', content: buildContentParts(query, decodedImages) }
   ]
   const toolCalls: ToolCall[] = []
+  const successfulToolResults: string[] = []
   const unified: UnifiedSource[] = []
   const unifiedKeys = new Set<string>()
   // Deferred image generation: keep EVERY request in tool-call order. The renderer generates after
@@ -697,7 +705,13 @@ export async function toolChat(
     }
   }
 
-  const maxToolCalls = llm.getSettings().maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS
+  const settings = llm.getSettings()
+  const maxToolCalls = normalizeMaxToolCalls(settings.maxToolCalls)
+  const answerFrom = (content: string): string => {
+    const answer = finalResponseFromToolResults(content, successfulToolResults)
+    if (!content.trim() && answer) onDelta(answer, 'content')
+    return answer
+  }
   let round = 0
   while (toolCalls.length < maxToolCalls) {
     // Stream this round: reasoning + any answer text flow through onDelta live; tool_calls
@@ -744,8 +758,7 @@ export async function toolChat(
     if (effective.length) {
       // One model round can request several tools in parallel. Count the actual calls, as Mobile
       // does, and execute only the remaining allowance so the configured ceiling stays truthful.
-      const remaining = maxToolCalls - toolCalls.length
-      const callsToRun = effective.slice(0, remaining)
+      const callsToRun = callsWithinToolBudget(effective, toolCalls.length, maxToolCalls)
       // Re-add the assistant turn (with its tool_calls) so the model sees what it invoked.
       messages.push({
         role: 'assistant',
@@ -769,7 +782,16 @@ export async function toolChat(
         // Uniform dispatch — every tool owns its own result. Merge any structured
         // side channels: sources are deduped into `unified` across rounds; image requests retain
         // call order for deferred generation after the turn.
-        const res = await runTool(c.name, c.args, toolContext, exts)
+        const rawResult = await runTool(c.name, c.args, toolContext, exts)
+        const resultBudget = toolResultCharBudget({
+          contextLength: llm.effectiveContextSize(),
+          promptChars: toolPromptChars(messages, tools),
+          replyReserveTokens: settings.maxTokens
+        })
+        const res = {
+          ...rawResult,
+          text: boundToolResult(c.name, rawResult.text, resultBudget)
+        }
         for (const s of res.sources ?? []) {
           if (unifiedKeys.has(s.key)) continue
           unifiedKeys.add(s.key)
@@ -778,6 +800,7 @@ export async function toolChat(
         if (res.imageRequests?.length) imageRequests.push(...res.imageRequests)
         else if (res.imageRequest) imageRequests.push(res.imageRequest)
         const status = res.status ?? 'completed'
+        if (status === 'completed' && res.text.trim()) successfulToolResults.push(res.text)
         toolCalls.push({ name: c.name, args: c.args, result: res.text, status })
         // Surface the COMPLETED call (with its result) live, so the UI can show each
         // tool call + result as it lands, not only in the final batch.
@@ -792,7 +815,7 @@ export async function toolChat(
       continue // let the model use the results
     }
     // No tool calls this round: `content` is the final answer (already streamed via onDelta).
-    return resultWithImages({ answer: content.trim(), toolCalls, unified })
+    return resultWithImages({ answer: answerFrom(content), toolCalls, unified })
   }
   // The configured emergency cap was reached with the model still calling tools. Instead of dead-ending
   // with a canned "stopped" message, FORCE one final answer WITHOUT tools, so the
@@ -808,7 +831,7 @@ export async function toolChat(
     signal: opts.signal
   })
   return resultWithImages({
-    answer: final.content.trim() || 'Stopped after too many tool steps.',
+    answer: answerFrom(final.content) || 'Stopped after too many tool steps.',
     toolCalls,
     unified
   })

--- a/src/shared/llm-defaults.ts
+++ b/src/shared/llm-defaults.ts
@@ -21,13 +21,10 @@ export const MAX_TOKENS_AUTO = 0
 // Fresh-install / reset default for max output: auto (context is the limit, not a fixed number).
 export const DEFAULT_MAX_TOKENS = MAX_TOKENS_AUTO
 
-// Emergency ceiling for tool calls in one response. Keep this aligned with Off Grid AI Mobile so
-// a synced value has the same meaning on both products.
-export const MIN_MAX_TOOL_CALLS = 1
-export const MAX_MAX_TOOL_CALLS = 100
-export const DEFAULT_MAX_TOOL_CALLS = 25
-
-export function normalizeMaxToolCalls(value: number): number {
-  if (!Number.isFinite(value)) return DEFAULT_MAX_TOOL_CALLS
-  return Math.max(MIN_MAX_TOOL_CALLS, Math.min(MAX_MAX_TOOL_CALLS, Math.round(value)))
-}
+// Keep existing Desktop imports stable while Shared owns the cross-platform tool-call policy.
+export {
+  MIN_MAX_TOOL_CALLS,
+  MAX_MAX_TOOL_CALLS,
+  DEFAULT_MAX_TOOL_CALLS,
+  normalizeMaxToolCalls
+} from '@offgrid/models'


### PR DESCRIPTION
## User outcome

A Desktop tool reply cannot exceed the total call limit or overflow the active model window. If the model returns no final text after a successful tool, the user still receives the tool output.

## Scope

- Consume the canonical Shared tool-call budget and per-result size policy.
- Count parallel calls against the same total allowance.
- Bound results before they reach the model, event callback, or transcript.
- Use successful result text only when the model final response is empty.
- Keep Desktop as a thin consumer. Exclude application migration, workflow machinery, compatibility paths, and unrelated model/RAG migration drift.

## Passed checks

- `npm run test:db -- src/main/__tests__/tools-loop.dbtest.ts` - 33/33 passed through real `toolChat`, a fake native socket, and real SQLite
- Focused ESLint - zero errors
- Terminal development launch built main/preload, opened an isolated encrypted profile, started the renderer, and reached the model gateway
- `git diff codex/f3-project-cleanup...HEAD --check`
- CodeRabbit passed or skipped because the PR is draft

## Open gates

- Local node and web typechecks stop at existing Shared RAG interface drift in `rag/index.ts` and `rag/store.ts`.
- Hosted CI failed at existing Desktop Pro/application migration drift: missing later `@offgrid/models` and `@offgrid/sync` exports, missing `@offgrid/application` and later core modules, and their dependent type errors. This PR does not alter that excluded migration work.
- The user-triggered live Tool execution journey, behavioral UI proof, and visual inspection remain open because Computer Use/CUA is prohibited.
- No E2E tests were added or run, as requested.
- Production and packaged builds were not run because the live and behavioral UI gates are open.
- Mobile iOS Release simulator remains blocked by the installed `llama.rn` package, which has no `ios-arm64_x86_64-simulator` XCFramework slice.
- All listed physical iPhones are unavailable.

This PR must remain draft while these gates are open.