### PR TITLE
Recover F6 model transfer and accepted Desktop fixes

### DIFF
--- a/docs/GAPS_BACKLOG.md
+++ b/docs/GAPS_BACKLOG.md
@@ -7,6 +7,38 @@ how to reproduce, and the fix direction. Close with evidence; never hide.
 
 ## OPEN
 
+### REC-F6-001 (P1) - Desktop recovery backlog items need final review
+
+**Status:** open; reported during the cumulative F6 manual pass on 2026-09-11. These items are
+observations and possible earlier product work. They are not approved implementation scope and have
+not yet been classified against the pre-migration baseline.
+
+Review these items together at the end of the current manual pass so none are lost:
+
+1. **Chat typing speed:** typing in the Desktop chat composer is slow. The user reports that an
+   earlier change fixed this, but that change does not appear to be integrated into the cumulative
+   F6 state. Reproduce and measure input latency before classifying or recovering the earlier work.
+2. **Connector-backed chat queries:** review the earlier work that made enabled connectors available
+   to chat queries. Prove the missing user outcome on the baseline and distinguish useful connector
+   query support from Shared-model migration or migration-regression work.
+3. **Multiple Google accounts:** review the earlier support for adding more than one Google account
+   through the connector integration. Verify account identity, separate credentials, selection,
+   reconnect, and query routing without exposing one account's data or token to another account.
+4. **Image intent from normal chat:** a prompt such as "Draw a dog" does not start image generation
+   unless the user first selects Image mode. Review whether the normal chat planner should route a
+   clear image request to image generation while keeping Image mode as an explicit direct control.
+5. **Startup loader:** Desktop startup shows a spinning loader instead of the intended three-dot
+   loader. Restore the standard startup indicator and verify the loading, ready, and failure states.
+6. **Two-way model transfer:** sending a model must work in both directions: Desktop to Mobile and
+   Mobile to Desktop. Verify discovery, transfer progress, completion, cancellation, failure,
+   retry, and that the received model is usable after each app restarts.
+
+**Evidence required to close:** classify each item through the chronological recovery audit; obtain
+approval before changing code; then run the accepted real Desktop journey. For typing, record input
+latency before and after. For connector queries and multiple Google accounts, use real connector and
+provider boundaries with redacted evidence. For model transfer, run the same accepted journey in
+both directions with real Desktop and Mobile devices.
+
 ### CU-004 (P1) - The current vision-first paths lack complete live control proof
 
 **Earlier Web Use evidence (2026-08-25):** `scripts/qa-agentic-studio.mjs` ran a deterministic Web

--- a/docs/GAPS_BACKLOG.md
+++ b/docs/GAPS_BACKLOG.md
@@ -1273,6 +1273,12 @@ that has to watch journeys it is not driving.
 
 **Status:** partially fixed 2026-08-07. Found by looking at both screens during a real macOS -> iOS send.
 
+**F6 evidence, 2026-09-11:** Desktop and Mobile now advertise model-transfer support explicitly,
+and saved or discovered peer facts keep that capability. Focused Shared and app integration checks
+pass, and both development apps start with the new wiring. This does not close the gap. A real
+multi-GB transfer, interruption and resume, receiver load, sender/receiver completion agreement, and
+visual review still need two physical devices. This task did not control the UI.
+
 **Symptom.** The Mac reported the model sent successfully. The iPhone reported the same transfer as
 "could not receive / interrupted". Both screens were honest about their own side, and the user has no
 way to know which to believe.

--- a/e2e/app-launch.spec.ts
+++ b/e2e/app-launch.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test, type ElectronApplication, type Page } from '@playwright/test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { launchOffGrid } from './helpers/launch'
+
+let app: ElectronApplication
+let page: Page
+let userDataDir: string
+
+test.beforeAll(async () => {
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'offgrid-app-launch-'))
+  app = await launchOffGrid({
+    env: {
+      ...process.env,
+      OFFGRID_USER_DATA: userDataDir,
+      OFFGRID_PRO: '0',
+      NODE_ENV: 'production'
+    }
+  })
+  page = await app.firstWindow()
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  fs.rmSync(userDataDir, { recursive: true, force: true })
+})
+
+test('the first window renders and startup settles without blocking it', async () => {
+  await page.waitForLoadState('domcontentloaded')
+  await expect(page.locator('#root')).not.toBeEmpty()
+  await expect(
+    page.getByText('Off Grid AI Desktop could not finish startup. Restart the app.')
+  ).toHaveCount(0)
+  await expect(page.getByText(/did not finish|took longer than expected/)).toHaveCount(0, {
+    timeout: 15_000
+  })
+})

--- a/e2e/app-restart-profile.spec.ts
+++ b/e2e/app-restart-profile.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type ElectronApplication } from '@playwright/test'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import electronExecutable from 'electron'
+import { launchOffGrid } from './helpers/launch'
+
+let app: ElectronApplication | undefined
+let profile: string
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(() => {
+  profile = fs.mkdtempSync(path.join(os.tmpdir(), 'offgrid-app-restart-'))
+})
+
+test.afterEach(async () => {
+  await app?.close().catch(() => undefined)
+  app = undefined
+})
+
+test.afterAll(() => {
+  fs.rmSync(profile, { recursive: true, force: true })
+})
+
+async function launchAndReadPaths(): Promise<{ userData: string; models: string }> {
+  app = await launchOffGrid({
+    env: {
+      ...process.env,
+      OFFGRID_USER_DATA: profile,
+      OFFGRID_PRO: '0',
+      OFFGRID_E2E_HEADLESS: '1',
+      OFFGRID_E2E_ISOLATED_INSTANCE: '1',
+      NODE_ENV: 'production'
+    }
+  })
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  return {
+    userData: await app.evaluate(({ app: electronApp }) => electronApp.getPath('userData')),
+    models: await page.evaluate(async () => (await window.api.checkModelStatus()).modelsDir)
+  }
+}
+
+test('keeps application and model storage in one selected profile across restart', async () => {
+  const first = await launchAndReadPaths()
+  expect(first).toEqual({ userData: profile, models: path.join(profile, 'models') })
+  expect(fs.existsSync(path.join(profile, 'memories.db'))).toBe(true)
+
+  await app?.close()
+  app = undefined
+
+  const second = await launchAndReadPaths()
+  expect(second).toEqual(first)
+  expect(fs.existsSync(path.join(profile, 'memories.db'))).toBe(true)
+})
+
+test('exits when an explicit profile cannot be established', async () => {
+  const invalidProfile = path.join(profile, 'not-a-directory')
+  fs.writeFileSync(invalidProfile, 'occupied by a file')
+  const environment = {
+    ...process.env,
+    OFFGRID_USER_DATA: invalidProfile,
+    OFFGRID_PRO: '0',
+    OFFGRID_E2E_HEADLESS: '1',
+    OFFGRID_E2E_ISOLATED_INSTANCE: '1',
+    NODE_ENV: 'production'
+  }
+  delete environment.ELECTRON_RUN_AS_NODE
+
+  const child = spawn(
+    electronExecutable as unknown as string,
+    [path.resolve('.'), '--server-only'],
+    {
+      cwd: path.resolve('.'),
+      env: environment,
+      stdio: ['ignore', 'ignore', 'pipe']
+    }
+  )
+  let stderr = ''
+  child.stderr?.setEncoding('utf8')
+  child.stderr?.on('data', (chunk: string) => {
+    stderr += chunk
+  })
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill()
+      reject(new Error('Electron continued after the explicit profile failed'))
+    }, 15_000)
+    child.once('exit', (code) => {
+      clearTimeout(timeout)
+      resolve(code)
+    })
+  })
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain('[userData] initialization failed')
+})

--- a/src/main/__tests__/image-generation-job-owner.integration.test.ts
+++ b/src/main/__tests__/image-generation-job-owner.integration.test.ts
@@ -8,6 +8,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import {
+  ImageGenerationPersistenceError,
   ImageGenerationJobService,
   type ImageGenerationJobRequest,
   type ImageGenerationRuntime
@@ -47,7 +48,9 @@ interface ControlledGeneration {
 
 function controlledRuntime(
   cancelResult = true,
-  saveScopeError?: Error
+  saveScopeError?: Error,
+  shareResult = true,
+  noteMessageResult = true
 ): {
   runtime: ImageGenerationRuntime
   generation(): ControlledGeneration
@@ -82,11 +85,11 @@ function controlledRuntime(
       // scope the sidecar was given, which is what the description is built from.
       share: (path) => {
         sharedPaths.push(path)
-        return true
+        return shareResult
       },
       noteMessage: (path, shownIn) => {
         notedMessages.push({ path, shownIn })
-        return true
+        return noteMessageResult
       },
       preserveSource: (syncId, sourcePath) => {
         preservedSources.push({ syncId, sourcePath })
@@ -258,7 +261,7 @@ describe('main-owned image generation job journeys', () => {
     })
   })
 
-  it('keeps a generated image successful when scope metadata cannot be saved', async () => {
+  it('fails with a typed persistence error when scope metadata cannot be committed', async () => {
     const boundary = controlledRuntime(true, new Error('scope database unavailable'))
     const jobs = new ImageGenerationJobService(boundary.runtime)
     const generation = jobs.start(request)
@@ -272,17 +275,17 @@ describe('main-owned image generation job journeys', () => {
 
     boundary.generation().succeed(output)
 
-    await expect(generation).resolves.toEqual({ ...output, syncId: jobs.status().id })
+    await expect(generation).rejects.toBeInstanceOf(ImageGenerationPersistenceError)
     expect(jobs.status()).toMatchObject({
-      phase: 'succeeded',
-      outputPath: output.path,
+      phase: 'failed',
+      outputPath: null,
       progress: null,
-      error: null
+      error: 'The generated image could not be committed to the image library.'
     })
     expect(boundary.savedScopes).toEqual([])
   })
 
-  it('completes an unscoped native result without writing metadata', async () => {
+  it('rejects a native result that has no owned output identity', async () => {
     const boundary = controlledRuntime()
     const jobs = new ImageGenerationJobService(boundary.runtime)
     const generation = jobs.start({ prompt: 'An unscoped image' })
@@ -295,8 +298,48 @@ describe('main-owned image generation job journeys', () => {
     }
 
     boundary.generation().succeed(output)
-    await expect(generation).resolves.toEqual({ ...output, syncId: jobs.status().id })
-    expect(jobs.status()).toMatchObject({ phase: 'succeeded', outputPath: '' })
+    await expect(generation).rejects.toMatchObject({
+      code: 'IMAGE_GENERATION_PERSISTENCE_FAILED',
+      imagePath: ''
+    })
+    expect(jobs.status()).toMatchObject({ phase: 'failed', outputPath: null })
     expect(boundary.savedScopes).toEqual([])
+  })
+
+  it('does not publish success when the committed sidecar cannot be shared', async () => {
+    const boundary = controlledRuntime(true, undefined, false)
+    const jobs = new ImageGenerationJobService(boundary.runtime)
+    const generation = jobs.start(request)
+    const output: ImageGenOutput = {
+      dataUrl: 'data:image/png;base64,aW1hZ2U=',
+      path: generatedFile('image-with-unshareable-sidecar.png'),
+      seed: 91,
+      model: 'Local image model',
+      prompt: request.prompt
+    }
+
+    boundary.generation().succeed(output)
+
+    await expect(generation).rejects.toBeInstanceOf(ImageGenerationPersistenceError)
+    expect(jobs.status()).toMatchObject({ phase: 'failed', outputPath: null })
+  })
+
+  it('surfaces a typed failure when the durable message association cannot be saved', async () => {
+    const boundary = controlledRuntime(true, undefined, true, false)
+    const jobs = new ImageGenerationJobService(boundary.runtime)
+    const generation = jobs.start({ ...request, messageId: undefined })
+    const output: ImageGenOutput = {
+      dataUrl: 'data:image/png;base64,aW1hZ2U=',
+      path: generatedFile('image-awaiting-message.png'),
+      seed: 91,
+      model: 'Local image model',
+      prompt: request.prompt
+    }
+
+    boundary.generation().succeed(output)
+    await expect(generation).resolves.toMatchObject({ path: output.path })
+    expect(() => jobs.acknowledgeConversation(request.conversationId!, 'message-later')).toThrow(
+      ImageGenerationPersistenceError
+    )
   })
 })

--- a/src/main/__tests__/image-generation-navigation.integration.dbtest.ts
+++ b/src/main/__tests__/image-generation-navigation.integration.dbtest.ts
@@ -33,6 +33,8 @@ vi.mock('electron', () => ({
 }))
 
 const IMAGE_MODEL = 'navigation-image-fixture.safetensors'
+const CONVERSATION_ID = '11111111-1111-4111-8111-111111111111'
+const MESSAGE_ID = '22222222-2222-4222-8222-222222222222'
 const PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
 
@@ -80,7 +82,7 @@ describe('image generation across feature navigation', () => {
     const generation = jobs.start({
       prompt: 'A green cabin rendered while navigating',
       model: IMAGE_MODEL,
-      conversationId: 'conversation-navigation',
+      conversationId: CONVERSATION_ID,
       projectId: 'project-navigation',
       seed: 91,
       width: 512,
@@ -89,7 +91,7 @@ describe('image generation across feature navigation', () => {
     })
     expect(jobs.status()).toMatchObject({
       phase: 'running',
-      conversationId: 'conversation-navigation',
+      conversationId: CONVERSATION_ID,
       projectId: 'project-navigation'
     })
 
@@ -103,16 +105,35 @@ describe('image generation across feature navigation', () => {
     expect(returnedScreen).toContain('succeeded')
     expect(jobs.status()).toMatchObject({
       phase: 'succeeded',
-      conversationId: 'conversation-navigation',
+      conversationId: CONVERSATION_ID,
       outputPath: image.path
+    })
+    expect(JSON.parse(fs.readFileSync(`${image.path}.json`, 'utf8'))).toMatchObject({
+      syncId: image.syncId,
+      conversationId: CONVERSATION_ID
     })
 
     const refreshed: string[] = []
     const detachRefresh = jobs.onConversationUpdated((conversationId) =>
       refreshed.push(conversationId)
     )
-    expect(jobs.acknowledgeConversation('conversation-navigation')).toBe(true)
-    expect(refreshed).toEqual(['conversation-navigation'])
+    const { getDB } = await import('../database')
+    getDB()
+      .prepare(
+        `INSERT INTO rag_conversations (id, title)
+         VALUES (?, ?)`
+      )
+      .run(CONVERSATION_ID, 'Navigation image')
+    getDB()
+      .prepare(
+        `INSERT INTO rag_messages (uuid, conversation_id, role, content)
+         VALUES (?, ?, 'assistant', ?)`
+      )
+      .run(MESSAGE_ID, CONVERSATION_ID, 'Generated image')
+    expect(
+      jobs.acknowledgeConversation(CONVERSATION_ID, MESSAGE_ID)
+    ).toBe(true)
+    expect(refreshed).toEqual([CONVERSATION_ID])
     detachRefresh()
     detachReturned()
   }, 15_000)

--- a/src/main/__tests__/image-runtime-reliability.integration.dbtest.ts
+++ b/src/main/__tests__/image-runtime-reliability.integration.dbtest.ts
@@ -526,7 +526,7 @@ describe('multimodal runtime reliability', () => {
 
     expect(imageLibrary.listGeneratedImages({ conversationId: 'image-release-chat' })).toEqual([
       expect.objectContaining({
-        path: image.path,
+        path: fs.realpathSync(image.path),
         conversationId: 'image-release-chat',
         projectId: 'image-release-project'
       })
@@ -544,7 +544,10 @@ describe('multimodal runtime reliability', () => {
     const reopenedImages = await import('../imagegen')
     const reopenedArtifacts = await import('../artifacts')
     expect(reopenedImages.listGeneratedImages({ projectId: 'image-release-project' })).toEqual([
-      expect.objectContaining({ path: image.path, conversationId: 'image-release-chat' })
+      expect.objectContaining({
+        path: fs.realpathSync(image.path),
+        conversationId: 'image-release-chat'
+      })
     ])
     expect(reopenedArtifacts.listArtifacts({ conversationId: 'image-release-chat' })).toEqual([
       expect.objectContaining({ id: savedArtifact.id, kind: 'image', code: image.path })

--- a/src/main/__tests__/product-identity.test.ts
+++ b/src/main/__tests__/product-identity.test.ts
@@ -64,12 +64,21 @@ describe('installed product identity', () => {
     expect(localBuild).not.toMatch(/-c\.productName="Off Grid AI(?: Pro)?"/)
 
     const main = fs.readFileSync(path.join(root, 'src/main/index.ts'), 'utf8')
-    const bootstrap = main.indexOf('beginProductIdentityBootstrap(app, process.platform)')
+    const userDataBootstrap = fs.readFileSync(
+      path.join(root, 'src/main/bootstrap/user-data.ts'),
+      'utf8'
+    )
+    const firstImport = main.indexOf(
+      "import { restoreCanonicalProductName } from './bootstrap/user-data'"
+    )
     const ready = main.indexOf('app.whenReady().then')
     const restore = main.indexOf('restoreCanonicalProductName()', ready)
     const serverOnly = main.indexOf("process.argv.includes('--server-only')", ready)
-    expect(bootstrap).toBeGreaterThan(-1)
-    expect(bootstrap).toBeLessThan(ready)
+    expect(firstImport).toBe(0)
+    expect(userDataBootstrap).toContain('beginProductIdentityBootstrap(app, process.platform)')
+    expect(userDataBootstrap).toContain("app.setPath('userData', process.env.OFFGRID_USER_DATA)")
+    expect(userDataBootstrap).toContain('app.exit(1)')
+    expect(userDataBootstrap).toContain('throw error')
     expect(restore).toBeGreaterThan(ready)
     expect(restore).toBeLessThan(serverOnly)
     expect(main).toContain('applicationName: PRODUCT_NAME')

--- a/src/main/__tests__/rag-ipc-project-create.dbtest.ts
+++ b/src/main/__tests__/rag-ipc-project-create.dbtest.ts
@@ -20,6 +20,7 @@ vi.mock('electron', () => ({
 }))
 
 import { setupRagIPC } from '../rag-ipc'
+import { getDB } from '../database'
 import { listProjects } from '../rag/store'
 
 afterAll(() => {
@@ -80,5 +81,32 @@ describe('project IPC persistence', () => {
       icon: 'rocket',
       includeMemory: false
     })
+  })
+
+  it('returns a refusal and preserves the project when the database transaction fails', () => {
+    setupRagIPC()
+    const create = handlers.get('projects:create')
+    const remove = handlers.get('projects:delete')
+    expect(create).toBeTypeOf('function')
+    expect(remove).toBeTypeOf('function')
+
+    const projectId = create!(undefined, { name: 'Protected project' }) as string
+    getDB().exec(`
+      CREATE TRIGGER refuse_project_delete
+      BEFORE DELETE ON projects
+      BEGIN
+        SELECT RAISE(ABORT, 'knowledge cleanup did not finish');
+      END;
+    `)
+
+    expect(remove!(undefined, projectId)).toEqual({
+      ok: false,
+      reason: 'knowledge cleanup did not finish'
+    })
+    expect(listProjects()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: projectId, name: 'Protected project' })
+      ])
+    )
   })
 })

--- a/src/main/__tests__/startup-ipc.test.ts
+++ b/src/main/__tests__/startup-ipc.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronBoundary = vi.hoisted(() => {
+  const handlers = new Map<string, () => unknown>()
+  const send = vi.fn()
+  const removeHandler = vi.fn((channel: string) => handlers.delete(channel))
+  return {
+    handlers,
+    send,
+    removeHandler,
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: () => unknown) => handlers.set(channel, handler)),
+      removeHandler
+    },
+    windows: [
+      { isDestroyed: () => false, webContents: { send } },
+      { isDestroyed: () => true, webContents: { send: vi.fn() } }
+    ]
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: electronBoundary.ipcMain,
+  BrowserWindow: { getAllWindows: () => electronBoundary.windows }
+}))
+
+import { registerStartupStatusIpc } from '../startup-ipc'
+import { startupProjection } from '../startup-projection'
+
+describe('startup status IPC', () => {
+  beforeEach(() => {
+    electronBoundary.handlers.clear()
+    electronBoundary.send.mockClear()
+    electronBoundary.removeHandler.mockClear()
+  })
+
+  it('returns the current snapshot, publishes changes, and fully unregisters', () => {
+    const stop = registerStartupStatusIpc()
+    const read = electronBoundary.handlers.get('app:startup-status')
+    expect(read?.()).toEqual(startupProjection.snapshot())
+
+    const stage = `ipc-${crypto.randomUUID()}`
+    startupProjection.stageStarted({ name: stage, required: false })
+    expect(electronBoundary.send).toHaveBeenCalledWith(
+      'app:startup-status-changed',
+      expect.objectContaining({ running: expect.arrayContaining([stage]) })
+    )
+
+    const sent = electronBoundary.send.mock.calls.length
+    stop()
+    startupProjection.stageSettled({
+      name: stage,
+      status: 'completed',
+      required: false,
+      durationMs: 1
+    })
+    expect(electronBoundary.send).toHaveBeenCalledTimes(sent)
+    expect(electronBoundary.removeHandler).toHaveBeenCalledWith('app:startup-status')
+  })
+})

--- a/src/main/__tests__/startup-projection.test.ts
+++ b/src/main/__tests__/startup-projection.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { createStartupProjection } from '../startup-projection'
+
+describe('startup projection', () => {
+  it('returns to ready when every running stage completes', () => {
+    const projection = createStartupProjection()
+
+    projection.stageStarted({ name: 'core', required: true })
+    projection.stageStarted({ name: 'optional', required: false })
+    expect(projection.snapshot().phase).toBe('pending')
+    expect(projection.snapshot().running).toEqual(['core', 'optional'])
+
+    projection.stageSettled({
+      name: 'core',
+      status: 'completed',
+      required: true,
+      durationMs: 4
+    })
+    projection.stageSettled({
+      name: 'optional',
+      status: 'completed',
+      required: false,
+      durationMs: 8
+    })
+
+    expect(projection.snapshot()).toMatchObject({ phase: 'ready', running: [] })
+  })
+
+  it('keeps required failures distinct from optional degradation', () => {
+    const optional = createStartupProjection()
+    optional.stageSettled({
+      name: 'optional',
+      status: 'timeout',
+      required: false,
+      durationMs: 20,
+      error: 'exceeded 20ms'
+    })
+    expect(optional.snapshot().phase).toBe('degraded')
+
+    const required = createStartupProjection()
+    required.stageSettled({
+      name: 'required',
+      status: 'failed',
+      required: true,
+      durationMs: 2,
+      error: 'failed'
+    })
+    expect(required.snapshot().phase).toBe('failed')
+  })
+
+  it('publishes increasing revisions and stops after unsubscribe', () => {
+    const projection = createStartupProjection()
+    const revisions: number[] = []
+    const unsubscribe = projection.subscribe((snapshot) => revisions.push(snapshot.revision))
+
+    projection.stageStarted({ name: 'core', required: true })
+    projection.stageSettled({
+      name: 'core',
+      status: 'completed',
+      required: true,
+      durationMs: 1
+    })
+    unsubscribe()
+    projection.stageStarted({ name: 'later', required: false })
+
+    expect(revisions).toEqual([1, 2])
+  })
+})

--- a/src/main/__tests__/startup-stages.test.ts
+++ b/src/main/__tests__/startup-stages.test.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runStartupStage } from '../startup-stages'
+import { startupProjection } from '../startup-projection'
+
+const delay = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+let temporaryRoot = ''
+const originalLogPath = process.env.OFFGRID_DIAGNOSTIC_LOG
+
+beforeEach(() => {
+  temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'offgrid-startup-test-'))
+  process.env.OFFGRID_DIAGNOSTIC_LOG = path.join(temporaryRoot, 'startup.log')
+})
+
+afterEach(() => {
+  if (originalLogPath === undefined) delete process.env.OFFGRID_DIAGNOSTIC_LOG
+  else process.env.OFFGRID_DIAGNOSTIC_LOG = originalLogPath
+  fs.rmSync(temporaryRoot, { recursive: true, force: true })
+})
+
+describe('startup stages', () => {
+  it('refuses a guarded change after the stage deadline', async () => {
+    let applied = false
+    const stageName = `guarded-${crypto.randomUUID()}`
+
+    const result = await runStartupStage({
+      name: stageName,
+      deadlineMs: 5,
+      lateEffect: 'guard',
+      run: async (context) => {
+        await delay(20)
+        context.commit('apply late result', () => {
+          applied = true
+        })
+      }
+    })
+    await delay(30)
+
+    expect(result).toMatchObject({ ok: false, reason: 'timeout' })
+    expect(applied).toBe(false)
+    expect(
+      startupProjection.snapshot().stages.find((stage) => stage.name === stageName)?.status
+    ).toBe('timeout')
+  })
+
+  it('records an allowed late result without leaving startup pending', async () => {
+    const stageName = `keep-${crypto.randomUUID()}`
+
+    const result = await runStartupStage({
+      name: stageName,
+      deadlineMs: 5,
+      lateEffect: 'keep',
+      run: async () => delay(20)
+    })
+    await delay(30)
+
+    expect(result).toMatchObject({ ok: false, reason: 'timeout' })
+    expect(
+      startupProjection.snapshot().stages.find((stage) => stage.name === stageName)?.status
+    ).toBe('late')
+    expect(startupProjection.snapshot().running).not.toContain(stageName)
+  })
+
+  it('turns a synchronous stage exception into a typed failure', async () => {
+    const result = await runStartupStage({
+      name: `failure-${crypto.randomUUID()}`,
+      deadlineMs: 50,
+      required: true,
+      lateEffect: 'guard',
+      run: () => {
+        throw new Error('startup failed')
+      }
+    })
+
+    expect(result).toMatchObject({ ok: false, reason: 'failed', error: 'startup failed' })
+  })
+})

--- a/src/main/__tests__/startup-stages.test.ts
+++ b/src/main/__tests__/startup-stages.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { runStartupStage } from '../startup-stages'
+import { runIndependentStartupStages, runStartupStage } from '../startup-stages'
 import { startupProjection } from '../startup-projection'
 
 const delay = (milliseconds: number): Promise<void> =>
@@ -23,6 +23,49 @@ afterEach(() => {
 })
 
 describe('startup stages', () => {
+  it('applies an owned change and returns the stage value', async () => {
+    const applied: string[] = []
+    const result = await runStartupStage({
+      name: `success-${crypto.randomUUID()}`,
+      deadlineMs: 50,
+      required: true,
+      lateEffect: 'guard',
+      run: (context) => {
+        expect(context.signal.aborted).toBe(false)
+        expect(context.isOwner()).toBe(true)
+        return context.commit('record result', () => {
+          applied.push('done')
+          return 42
+        })
+      }
+    })
+
+    expect(result).toMatchObject({ ok: true, value: 42 })
+    expect(applied).toEqual(['done'])
+  })
+
+  it('runs independent stages and preserves each result', async () => {
+    const results = await runIndependentStartupStages([
+      {
+        name: `first-${crypto.randomUUID()}`,
+        deadlineMs: 50,
+        lateEffect: 'keep',
+        run: () => 'first'
+      },
+      {
+        name: `second-${crypto.randomUUID()}`,
+        deadlineMs: 50,
+        lateEffect: 'guard',
+        run: () => 'second'
+      }
+    ])
+
+    expect(results).toEqual([
+      expect.objectContaining({ ok: true, value: 'first' }),
+      expect.objectContaining({ ok: true, value: 'second' })
+    ])
+  })
+
   it('refuses a guarded change after the stage deadline', async () => {
     let applied = false
     const stageName = `guarded-${crypto.randomUUID()}`

--- a/src/main/__tests__/tools-loop.dbtest.ts
+++ b/src/main/__tests__/tools-loop.dbtest.ts
@@ -498,6 +498,32 @@ describe('agentic tool loop — real toolChat + real LLMService over a fake llam
     }
   })
 
+  it('never saves a second Gemma tool request as the final answer after the limit', async () => {
+    await llm.setSettings({ maxToolCalls: 1 })
+    try {
+      enqueueReactiveAfterEmptyPlan(
+        { toolCalls: [{ name: 'calculator', args: { expression: '2+2' } }] },
+        {
+          content: '<|tool_call>call:web_use{query:<|"|>Off Grid AI information<|"|>}<tool_call|>'
+        }
+      )
+      const deltas: string[] = []
+
+      const result = await toolChat('calculate 2+2, then search for Off Grid AI', [], {
+        onDelta: (text, kind) => {
+          if (kind === 'content') deltas.push(text)
+        }
+      })
+
+      expect(result.toolCalls).toHaveLength(1)
+      expect(result.answer).toBe('4')
+      expect(result.answer).not.toMatch(/tool_call|web_use/i)
+      expect(deltas.join('')).toBe('4')
+    } finally {
+      await llm.setSettings({ maxToolCalls: 25 })
+    }
+  })
+
   it('counts parallel tool calls against the configured emergency limit', async () => {
     await llm.setSettings({ maxToolCalls: 2 })
     try {

--- a/src/main/__tests__/tools-loop.dbtest.ts
+++ b/src/main/__tests__/tools-loop.dbtest.ts
@@ -523,6 +523,61 @@ describe('agentic tool loop — real toolChat + real LLMService over a fake llam
     }
   })
 
+  it('shows successful tool output when the final model turn is empty', async () => {
+    enqueueReactiveAfterEmptyPlan(
+      { toolCalls: [{ name: 'calculator', args: { expression: '2+2' } }] },
+      { content: '' }
+    )
+    const deltas: string[] = []
+
+    const result = await toolChat('what is 2+2', [], {
+      onDelta: (text, kind) => {
+        if (kind === 'content') deltas.push(text)
+      }
+    })
+
+    expect(result.answer).toBe('4')
+    expect(deltas.join('')).toBe('4')
+  })
+
+  it('bounds each tool result to the room left in the active model window', async () => {
+    const raw = 'x'.repeat(30_000)
+    const extension = {
+      id: 'large-result-ext',
+      schemas: () => [
+        {
+          type: 'function',
+          function: {
+            name: 'large_result',
+            description: 'Return a large result',
+            parameters: { type: 'object', properties: {} }
+          }
+        }
+      ],
+      canHandle: (name: string) => name === 'large_result',
+      execute: async () => raw
+    }
+    registerToolExtension(extension)
+    const service = llm as unknown as { ctxSize: number }
+    const previousContext = service.ctxSize
+    service.ctxSize = 2_048
+    try {
+      enqueueReactiveAfterEmptyPlan(
+        { toolCalls: [{ name: 'large_result', args: {} }] },
+        { content: 'Used the bounded result.' }
+      )
+
+      const result = await toolChat('read it', [], { connectors: true })
+
+      expect(result.toolCalls[0]!.result.length).toBeLessThan(raw.length)
+      expect(result.toolCalls[0]!.result).toMatch(/result truncated: showing the first 1000/)
+      expect(JSON.stringify(fake.requests[1])).not.toContain(raw)
+    } finally {
+      service.ctxSize = previousContext
+      unregisterToolExtension(extension.id, extension)
+    }
+  })
+
   it('rejects a non-arithmetic calculator expression (real guard branch)', async () => {
     enqueueReactiveAfterEmptyPlan(
       { toolCalls: [{ name: 'calculator', args: { expression: 'process.exit(1)' } }] },

--- a/src/main/__tests__/user-data-bootstrap.test.ts
+++ b/src/main/__tests__/user-data-bootstrap.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronBoundary = vi.hoisted(() => ({
+  appData: '',
+  setName: vi.fn(),
+  setPath: vi.fn(),
+  exit: vi.fn(),
+  getPath: vi.fn((name: string) => {
+    if (name !== 'appData') throw new Error(`Unexpected Electron path: ${name}`)
+    return electronBoundary.appData
+  })
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: electronBoundary.getPath,
+    setName: electronBoundary.setName,
+    setPath: electronBoundary.setPath,
+    exit: electronBoundary.exit
+  }
+}))
+
+let root = ''
+const originalOverride = process.env.OFFGRID_USER_DATA
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'offgrid-user-data-'))
+  electronBoundary.appData = root
+  delete process.env.OFFGRID_USER_DATA
+})
+
+afterEach(() => {
+  if (originalOverride === undefined) delete process.env.OFFGRID_USER_DATA
+  else process.env.OFFGRID_USER_DATA = originalOverride
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('user-data bootstrap', () => {
+  it('uses an explicit profile and restores the visible product name', async () => {
+    const profile = path.join(root, 'explicit-profile')
+    process.env.OFFGRID_USER_DATA = profile
+
+    const bootstrap = await import('../bootstrap/user-data')
+
+    expect(fs.statSync(profile).isDirectory()).toBe(true)
+    expect(electronBoundary.setPath).toHaveBeenCalledWith('userData', profile)
+    bootstrap.restoreCanonicalProductName()
+    expect(electronBoundary.setName).toHaveBeenLastCalledWith('Off Grid AI Desktop')
+  })
+
+  it('moves legacy model and database data into the canonical profile', async () => {
+    const legacyModels = path.join(root, 'My Memories', 'models')
+    const legacyDatabase = path.join(root, 'my-memories', 'memories.db')
+    fs.mkdirSync(legacyModels, { recursive: true })
+    fs.mkdirSync(path.dirname(legacyDatabase), { recursive: true })
+    fs.writeFileSync(path.join(legacyModels, 'model.gguf'), 'model')
+    fs.writeFileSync(legacyDatabase, 'database')
+
+    await import('../bootstrap/user-data')
+
+    const canonical = path.join(root, 'Off Grid AI Desktop')
+    expect(fs.readFileSync(path.join(canonical, 'models', 'model.gguf'), 'utf8')).toBe('model')
+    expect(fs.readFileSync(path.join(canonical, 'memories.db'), 'utf8')).toBe('database')
+    expect(electronBoundary.setPath).toHaveBeenCalledWith('userData', canonical)
+  })
+})

--- a/src/main/bootstrap/user-data.ts
+++ b/src/main/bootstrap/user-data.ts
@@ -1,0 +1,59 @@
+import { app } from 'electron'
+import fs from 'node:fs'
+import { join } from 'node:path'
+import { beginProductIdentityBootstrap } from '../product-identity-lifecycle'
+import { repairMissingDefaultKeychainAtBootstrap } from '../secure-storage-bootstrap'
+
+let restoreProductName: (() => void) | null = null
+
+function initializeUserData(): void {
+  const security = repairMissingDefaultKeychainAtBootstrap(process.platform, app.isPackaged)
+  if (security?.status === 'repaired') console.warn(`[secure-storage] ${security.detail}`)
+  else if (security && security.status !== 'healthy') {
+    console.error(`[secure-storage] ${security.detail}`)
+  }
+
+  restoreProductName = beginProductIdentityBootstrap(app, process.platform)
+
+  if (process.env.OFFGRID_USER_DATA) {
+    fs.mkdirSync(process.env.OFFGRID_USER_DATA, { recursive: true })
+    app.setPath('userData', process.env.OFFGRID_USER_DATA)
+    console.log('[userData] override path:', process.env.OFFGRID_USER_DATA)
+    return
+  }
+
+  const appData = app.getPath('appData')
+  const canonical = join(appData, 'Off Grid AI Desktop')
+  fs.mkdirSync(canonical, { recursive: true })
+  const move = (fromDir: string, name: string): void => {
+    try {
+      const source = join(fromDir, name)
+      const destination = join(canonical, name)
+      if (fs.existsSync(source) && !fs.existsSync(destination)) {
+        fs.renameSync(source, destination)
+      }
+    } catch (error) {
+      console.warn('[userData] migrate skip', name, error)
+    }
+  }
+  move(join(appData, 'My Memories'), 'models')
+  move(join(appData, 'my-memories'), 'models')
+  move(join(appData, 'my-memories'), 'memories.db')
+  move(join(appData, 'My Memories'), 'memories.db')
+  app.setPath('userData', canonical)
+  console.log('[userData] canonical path:', canonical)
+}
+
+try {
+  initializeUserData()
+} catch (error) {
+  console.error('[userData] initialization failed', error)
+  app.exit(1)
+  throw error
+}
+
+/** Restore the visible product name after Electron finishes its secure-storage lookup. */
+export function restoreCanonicalProductName(): void {
+  if (!restoreProductName) throw new Error('User data was not initialized.')
+  restoreProductName()
+}

--- a/src/main/imagegen.ts
+++ b/src/main/imagegen.ts
@@ -11,6 +11,7 @@ import { modalityQueue, IMAGE_JOB, CHAT_JOB } from './modality-queue/queue'
 import { getResidencyMode } from './runtime-residency'
 import { llm } from './llm'
 import { getSetting } from './database'
+import { resolveImageParameters, type ImageParameterStore } from '@offgrid/models'
 import {
   generatedImageSidecarPath,
   readGeneratedImageSidecar,
@@ -127,20 +128,23 @@ export function listGeneratedImages(scope?: GeneratedImageScope): {
     let all = fs
       .readdirSync(dir)
       .filter((f) => /\.png$/i.test(f) && !f.startsWith('preview-'))
-      .map((f) => {
-        const p = path.join(dir, f)
+      .flatMap((f) => {
+        const ownedImage = resolveExistingOwnedEntry(dir, f)
+        if (!ownedImage) return []
         // The sidecar is the one owner of what is known about an image besides its bytes, including
         // the syncId that names it on the mesh. Read through that module so this scan and the sync
         // receiver cannot disagree about the shape.
-        const meta = readGeneratedImageSidecar(p)
-        return {
-          path: p,
-          name: f,
-          mtime: fs.statSync(p).mtimeMs,
-          syncId: meta.syncId,
-          conversationId: meta.conversationId,
-          projectId: meta.projectId ?? null
-        }
+        const meta = readGeneratedImageSidecar(ownedImage)
+        return [
+          {
+            path: ownedImage,
+            name: f,
+            mtime: fs.statSync(ownedImage).mtimeMs,
+            syncId: meta.syncId,
+            conversationId: meta.conversationId,
+            projectId: meta.projectId ?? null
+          }
+        ]
       })
       .sort((a, b) => b.mtime - a.mtime)
     if (scope?.conversationId) all = all.filter((r) => r.conversationId === scope.conversationId)
@@ -520,7 +524,22 @@ export async function generateImage(
   // image job below evicts the LLM, so the text pass must precede it. Gated by a
   // setting; failure/timeout silently keeps the original prompt.
   const enhanced = await maybeEnhancePrompt(params.prompt, onUpdate)
-  const effective = enhanced === params.prompt ? params : { ...params, prompt: enhanced }
+  const selectedModel = params.model ?? activeImageModel()
+  const modelParameters = selectedModel
+    ? resolveImageParameters(
+        { id: selectedModel },
+        getSetting<ImageParameterStore>('imageParams', {})
+      )
+    : null
+  const effective = {
+    ...params,
+    prompt: enhanced,
+    steps: params.steps ?? modelParameters?.steps,
+    cfgScale: params.cfgScale ?? modelParameters?.cfgScale,
+    // Keep source-derived dimensions for img2img when the caller did not choose a size.
+    width: params.width ?? (params.initImage ? undefined : modelParameters?.size),
+    height: params.height ?? (params.initImage ? undefined : modelParameters?.size)
+  }
   onUpdate?.({ stage: 'preparing', enhancedPrompt: enhanced })
   const progressObserver = onUpdate
     ? (progress: ImageGenProgress & { preview?: string }) =>

--- a/src/main/imagegen/__tests__/owned-path.integration.test.ts
+++ b/src/main/imagegen/__tests__/owned-path.integration.test.ts
@@ -54,6 +54,18 @@ describe('app-owned filesystem entries', () => {
     expect(resolveOwnedDestination(linkedRoot, '../../adapter.safetensors')).toBeNull()
   })
 
+  it('rejects an existing destination symlink that escapes the owned root', () => {
+    const realRoot = tempDir('offgrid-owned-root-')
+    const parent = tempDir('offgrid-owned-parent-')
+    const linkedRoot = path.join(parent, 'models')
+    fs.symlinkSync(realRoot, linkedRoot)
+    const outside = path.join(tempDir('offgrid-owned-outside-'), 'adapter.safetensors')
+    fs.writeFileSync(outside, 'outside')
+    fs.symlinkSync(outside, path.join(realRoot, 'adapter.safetensors'))
+
+    expect(resolveOwnedDestination(linkedRoot, 'adapter.safetensors')).toBeNull()
+  })
+
   it('requires caller-supplied absolute paths to name that exact owned child', () => {
     const root = tempDir('offgrid-owned-root-')
     const owned = path.join(root, 'image.png')
@@ -64,5 +76,16 @@ describe('app-owned filesystem entries', () => {
       resolveExistingOwnedPath(root, path.join(tempDir('offgrid-other-'), 'image.png'))
     ).toBeNull()
     expect(resolveExistingOwnedPath(root, `${root}-evil/image.png`)).toBeNull()
+  })
+
+  it('accepts one owned child through an equivalent canonical root', () => {
+    const realRoot = tempDir('offgrid-owned-root-')
+    const parent = tempDir('offgrid-owned-parent-')
+    const linkedRoot = path.join(parent, 'generated-images')
+    fs.symlinkSync(realRoot, linkedRoot)
+    const owned = path.join(realRoot, 'image.png')
+    fs.writeFileSync(owned, 'png')
+
+    expect(resolveExistingOwnedPath(linkedRoot, owned)).toBe(fs.realpathSync.native(owned))
   })
 })

--- a/src/main/imagegen/job-service.ts
+++ b/src/main/imagegen/job-service.ts
@@ -27,6 +27,19 @@ export type ImageGenerationJobRequest = ImageGenerationRequestContract & {
 type JobListener = (snapshot: ImageGenerationJobContract) => void
 type ConversationListener = (conversationId: string) => void
 
+export class ImageGenerationPersistenceError extends Error {
+  readonly code = 'IMAGE_GENERATION_PERSISTENCE_FAILED'
+
+  constructor(
+    readonly syncId: string,
+    readonly imagePath: string,
+    options: { cause: unknown }
+  ) {
+    super('The generated image could not be committed to the image library.', options)
+    this.name = 'ImageGenerationPersistenceError'
+  }
+}
+
 /** A finished image, and the name it answers to on every device. */
 export type ImageGenerationResult = ImageGenerationResultContract
 
@@ -75,6 +88,7 @@ const idleSnapshot = (): ImageGenerationJobContract => ({
 export class ImageGenerationJobService {
   private snapshot: ImageGenerationJobContract = idleSnapshot()
   private active = false
+  private messageId: string | null = null
   private readonly listeners = new Set<JobListener>()
   private readonly conversationListeners = new Set<ConversationListener>()
 
@@ -104,6 +118,7 @@ export class ImageGenerationJobService {
   async start(request: ImageGenerationJobRequest): Promise<ImageGenerationResult> {
     this.assertCanStart()
     this.active = true
+    this.messageId = request.messageId ?? null
     const id = randomUUID()
     this.snapshot = {
       id,
@@ -135,42 +150,42 @@ export class ImageGenerationJobService {
       // conversation; without it the gallery and the file record name the same picture differently.
       // Kept BEFORE the facts are written, so the record names a copy this app owns rather than a
       // path on the user's disk that can be moved the moment the generation ends.
+      if (!result.path) {
+        throw new ImageGenerationPersistenceError(id, '', {
+          cause: new Error('The native image runtime did not return an owned output path.')
+        })
+      }
       const keptSource = request.initImage
         ? this.runtime.preserveSource(id, request.initImage)
         : null
-      if (result.path) {
-        try {
-          this.runtime.saveScope(result.path, {
-            syncId: id,
-            ...(keptSource ? { initImage: keptSource } : {}),
-            ...(request.conversationId ? { conversationId: request.conversationId } : {}),
-            ...(request.messageId ? { messageId: request.messageId } : {}),
-            projectId: request.projectId ?? null,
-            createdAt: new Date(this.snapshot.startedAt ?? Date.now()).toISOString(),
-            ...(request.width ? { width: request.width } : {}),
-            ...(request.height ? { height: request.height } : {}),
-            // The shared names, so the phone reads what this Mac wrote. It wrote `model` and the
-            // phone reads `modelId`, so every image made here arrived with its model reading
-            // "synced" and its steps reading 0.
-            metadataJson: generatedImageMetadataJson({
-              prompt: result.prompt,
-              ...(request.negativePrompt === undefined
-                ? {}
-                : { negativePrompt: request.negativePrompt }),
-              ...(request.steps === undefined ? {} : { steps: request.steps }),
-              seed: result.seed,
-              modelId: result.model
-            })
+      try {
+        this.runtime.saveScope(result.path, {
+          syncId: id,
+          ...(keptSource ? { initImage: keptSource } : {}),
+          ...(request.conversationId ? { conversationId: request.conversationId } : {}),
+          ...(request.messageId ? { messageId: request.messageId } : {}),
+          projectId: request.projectId ?? null,
+          createdAt: new Date(this.snapshot.startedAt ?? Date.now()).toISOString(),
+          ...(request.width ? { width: request.width } : {}),
+          ...(request.height ? { height: request.height } : {}),
+          metadataJson: generatedImageMetadataJson({
+            prompt: result.prompt,
+            ...(request.negativePrompt === undefined
+              ? {}
+              : { negativePrompt: request.negativePrompt }),
+            ...(request.steps === undefined ? {} : { steps: request.steps }),
+            seed: result.seed,
+            modelId: result.model
           })
-        } catch (scopeError) {
-          console.error(
-            `[image-job] ${JSON.stringify({
-              event: 'save-scope-failed',
-              id,
-              error: scopeError instanceof Error ? scopeError.message : String(scopeError)
-            })}`
-          )
-        }
+        })
+      } catch (cause) {
+        throw new ImageGenerationPersistenceError(id, result.path, { cause })
+      }
+      const hasReservedMessageAssociation = Boolean(request.conversationId && request.messageId)
+      if (hasReservedMessageAssociation && !this.runtime.share(result.path)) {
+        throw new ImageGenerationPersistenceError(id, result.path, {
+          cause: new Error('The committed generated image could not be described for sharing.')
+        })
       }
       this.snapshot = {
         ...this.snapshot,
@@ -180,10 +195,6 @@ export class ImageGenerationJobService {
         progress: null,
         finishedAt: Date.now()
       }
-      // Described from the sidecar just written, by the one function the chat link also calls, so a
-      // picture offered when it is made and the same picture offered once its message exists cannot
-      // be described two different ways.
-      if (result.path) this.runtime.share(result.path)
       this.publish()
       console.log(`[image-job] ${JSON.stringify({ event: 'succeeded', id, path: result.path })}`)
       return { ...result, syncId: id }
@@ -238,8 +249,17 @@ export class ImageGenerationJobService {
       this.snapshot.conversationId !== conversationId
     )
       return false
+    const syncId = this.snapshot.id
+    if (!syncId) return false
+    if (!this.messageId && !messageId) return false
     if (messageId && this.snapshot.outputPath) {
-      this.runtime.noteMessage(this.snapshot.outputPath, { conversationId, messageId })
+      try {
+        if (!this.runtime.noteMessage(this.snapshot.outputPath, { conversationId, messageId })) {
+          throw new Error('The generated image could not be linked to its conversation message.')
+        }
+      } catch (cause) {
+        throw new ImageGenerationPersistenceError(syncId, this.snapshot.outputPath, { cause })
+      }
     }
     for (const listener of this.conversationListeners) {
       try {

--- a/src/main/imagegen/owned-path.ts
+++ b/src/main/imagegen/owned-path.ts
@@ -47,12 +47,25 @@ export function resolveOwnedDestination(root: string, name: string): string | nu
   const safeName = simpleEntryName(name)
   if (!safeName) return null
   const realRoot = canonicalRoot(root)
-  return realRoot ? path.join(realRoot, safeName) : null
+  if (!realRoot) return null
+  const destination = path.join(realRoot, safeName)
+  try {
+    const entry = fs.lstatSync(destination)
+    return entry.isSymbolicLink() || !entry.isFile() ? null : destination
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT' ? destination : null
+  }
 }
 
 /** Validate a caller-supplied absolute path as one existing direct child of `root`. */
 export function resolveExistingOwnedPath(root: string, candidate: string): string | null {
-  const name = path.basename(candidate)
-  if (path.resolve(candidate) !== path.resolve(root, name)) return null
-  return resolveExistingOwnedEntry(root, name)
+  if (!path.isAbsolute(candidate)) return null
+  const realRoot = canonicalRoot(root)
+  if (!realRoot) return null
+  try {
+    const realCandidate = fs.realpathSync.native(candidate)
+    return path.dirname(realCandidate) === realRoot ? realCandidate : null
+  } catch {
+    return null
+  }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,6 @@
+import { restoreCanonicalProductName } from './bootstrap/user-data'
 import { app, shell, BrowserWindow, protocol, session, desktopCapturer, screen } from 'electron'
-import { join } from 'path'
 import { tmpdir } from 'os'
-import fs from 'fs'
 
 // Custom scheme to serve local capture screenshots to the renderer (file:// is
 // blocked there). Registered before app 'ready'; handled after.
@@ -58,8 +57,6 @@ import { PRODUCT_NAME } from '../shared/product-identity'
 import { installMediaPermissionHandler } from './media-permission'
 import { localMediaRoots } from './media-roots'
 import { resourceDirs } from './runtime-env'
-import { beginProductIdentityBootstrap } from './product-identity-lifecycle'
-import { repairMissingDefaultKeychainAtBootstrap } from './secure-storage-bootstrap'
 import {
   installDiagnosticConsoleCapture,
   installIpcDiagnostics,
@@ -79,60 +76,6 @@ import { shutdownModelDownloads } from './models/download-queue'
 // Before anything logs: a broken stdout/stderr pipe (parent/e2e-harness exited, closed pipe)
 // must never crash main via an uncaught EPIPE. See stream-guards.ts.
 guardConsoleStreams([process.stdout, process.stderr])
-
-// Electron asks macOS for its safeStorage password during early bootstrap. Repair
-// the one safe, known-bad state before that lookup can trigger SecurityAgent's
-// generic "Keychain Not Found" dialog. This never creates or resets a Keychain.
-const secureStorageBootstrap = repairMissingDefaultKeychainAtBootstrap(
-  process.platform,
-  app.isPackaged
-)
-if (secureStorageBootstrap?.status === 'repaired') {
-  console.warn(`[secure-storage] ${secureStorageBootstrap.detail}`)
-} else if (secureStorageBootstrap && secureStorageBootstrap.status !== 'healthy') {
-  console.error(`[secure-storage] ${secureStorageBootstrap.detail}`)
-}
-
-// Pin one canonical userData dir ("Off Grid AI Desktop") regardless of package
-// name, and migrate data from the legacy split dirs ("My Memories" had the
-// models, "my-memories" had the DB) so nothing is lost / re-downloaded. Must run
-// before app 'ready' and before any getPath('userData') usage.
-// Preserve the Keychain namespace used by every existing install during Electron's
-// early safeStorage bootstrap. The returned callback restores the canonical visible
-// product name at the beginning of the ready phase.
-const restoreCanonicalProductName = beginProductIdentityBootstrap(app, process.platform)
-;(function unifyUserDataPath(): void {
-  try {
-    // Test/CI seam: let a harness isolate userData (e.g. screenshot capture of
-    // a fresh, pre-onboarding profile). Harmless in production (unset).
-    if (process.env.OFFGRID_USER_DATA) {
-      fs.mkdirSync(process.env.OFFGRID_USER_DATA, { recursive: true })
-      app.setPath('userData', process.env.OFFGRID_USER_DATA)
-      console.log('[userData] override path:', process.env.OFFGRID_USER_DATA)
-      return
-    }
-    const appData = app.getPath('appData')
-    const canonical = join(appData, 'Off Grid AI Desktop')
-    fs.mkdirSync(canonical, { recursive: true })
-    const move = (fromDir: string, name: string): void => {
-      try {
-        const src = join(fromDir, name)
-        const dst = join(canonical, name)
-        if (fs.existsSync(src) && !fs.existsSync(dst)) fs.renameSync(src, dst)
-      } catch (e) {
-        console.warn('[userData] migrate skip', name, e)
-      }
-    }
-    move(join(appData, 'My Memories'), 'models')
-    move(join(appData, 'my-memories'), 'models')
-    move(join(appData, 'my-memories'), 'memories.db')
-    move(join(appData, 'My Memories'), 'memories.db')
-    app.setPath('userData', canonical)
-    console.log('[userData] canonical path:', canonical)
-  } catch (e) {
-    console.error('[userData] unify failed', e)
-  }
-})()
 
 installDiagnosticConsoleCapture()
 writeDiagnosticLog('app', 'bootstrap.started', {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,6 +65,8 @@ import {
   installIpcDiagnostics,
   writeDiagnosticLog
 } from './diagnostics-log'
+import { registerStartupStatusIpc } from './startup-ipc'
+import { runIndependentStartupStages, runStartupStage } from './startup-stages'
 import {
   applicationShutdown,
   commitApplicationRelaunch,
@@ -402,97 +404,181 @@ app.whenReady().then(async () => {
     optimizer.watchWindowShortcuts(window)
   })
 
-  // 2. Setup IPC Handlers (core) + the local model gateway
-  try {
-    installIpcDiagnostics(ipcMain)
-    // Licensing first: load the cached Keygen entitlement into memory and register
-    // the SYNC `pro:is-enabled` handler BEFORE createWindow() (line below) so the
-    // preload's sendSync resolves and window.api.isPro reflects the real license.
-    await loadProEntitlementProvider()
-    initLicensing()
-    await revalidateProEntitlement('launch')
-    setupLicenseIpc()
-    const entitlementRefresh = setInterval(() => {
-      refreshCachedProEntitlement()
-      void revalidateProEntitlement('foreground')
-    }, PERSONAL_MESH_ENTITLEMENT_REVALIDATION_INTERVAL_MS)
-    entitlementRefresh.unref()
-    applicationShutdown.register({
-      name: 'pro:entitlement-refresh',
-      shutdown: () => clearInterval(entitlementRefresh)
-    })
-    setupIPC()
-    setupRagIPC()
-    setupMcpIpc() // basic MCP connectors (management + chat tool extension)
-    registerNativeActionTools(registerToolExtension) // the assistant's tools (macOS full set; Windows Outlook subset)
-    const { registerActionsIpc } = await import('./actions/actions-ipc')
-    registerActionsIpc() // Approval UX v2: inline gate cards + outcome/undo feed
-    const { registerBrowserViewIpc } = await import('./browser/browser-host')
-    registerBrowserViewIpc() // dock the live browser view to the pane's region
-    const { registerVisionIpc } = await import('./vision/vision-controller')
-    registerVisionIpc() // the vision rail's supervisor Stop/Pause/Resume
-    const { registerSupervisorWindowIpc } = await import('./vision/supervisor-window')
-    registerSupervisorWindowIpc()
-    const { registerTaskHistoryIpc } = await import('./tasks/task-history-ipc')
-    registerTaskHistoryIpc() // one durable Web Use + Computer Use history
-    setupDesktopBackupIPC()
-    // one OpenAI-compatible local gateway (LLM + STT); auto-picks a free port. Async, so handle a
-    // rejection on the promise (a try/catch around a fire-and-forget async call can't catch it).
-    startModelServer().catch((e) => console.error('[model-server] start failed', e))
-    startMediaServer() // loopback HTTP for seekable local media (meeting videos)
-    // Heal a stale active-model.json whose model gained a vision projector after it was
-    // activated (e.g. Gemma 4 E2B) — turns vision on at launch if the projector is now
-    // on disk, without waiting for a re-activate.
-    void import('./models-manager').then((m) => m.reconcileActiveModelProjector()).catch(() => {})
-    ipcMain.handle('media:url', (_e, absPath: string) => mediaUrlFor(absPath))
-    // (clipboard is now a pro feature — setupClipboard runs in pro's activateMain)
-    // Pro features (capture, CRM, meetings, connectors, secretary, proactive,
-    // skills engine, console, tray) register their own IPC + intervals/capture loop
-    // here. No-op in the free build (the pro submodule is absent → stub).
-    void loadProFeaturesMain().catch((e) => console.error('[pro] load failed', e))
-    // Demo seeder for testing: OFFGRID_SEED=1 seeds once; OFFGRID_SEED=force re-seeds.
-    if (process.env.OFFGRID_SEED) {
-      void import('./dev-seed')
-        .then((m) => m.seedDemo(process.env.OFFGRID_SEED === 'force'))
-        .catch((e) => console.error('[seed]', e))
-    }
-    console.log('IPC Handlers Registered.')
-  } catch (e) {
-    console.error('FATAL: IPC Setup failed', e)
-  }
-
-  // 3. Initialize LLM (Async)
-  // We don't await this to avoid blocking window creation
-  import('./llm').then(({ llm }) => {
-    // Register the chat engine through the shared residency seam (runtime-manager),
-    // exactly like every other engine — the queue evicts it before a competing
-    // heavy job and re-warms it mode-aware (resident = reload; on-demand = release
-    // the pause block so it lazily respawns on next use, freeing RAM meanwhile).
-    registerRuntime(llm.runtime)
-    // Apply persisted queue settings (defaults: enabled, tier-1 coexists) — the
-    // keys + apply live in modality-queue/config so the settings UI shares them.
-    applyQueueConfig(modalityQueue, readQueueConfig(getSetting))
-    llm.init().catch((err) => console.error('Failed to init LLM:', err))
+  installIpcDiagnostics(ipcMain)
+  applicationShutdown.register({
+    name: 'startup:status-ipc',
+    shutdown: registerStartupStatusIpc()
   })
-  // Every other engine joins the SAME residency seam (runtime-manager), lazily so
-  // module load never blocks window creation. Registration only stores hooks — it
-  // doesn't spawn anything until the engine is actually used.
-  import('./tts').then(({ ttsRuntime }) => registerRuntime(ttsRuntime)).catch(() => {})
-  import('./imagegen').then(({ imageRuntime }) => registerRuntime(imageRuntime)).catch(() => {})
-  import('./transcription/select')
-    .then(({ sttRuntime }) => registerRuntime(sttRuntime))
-    .catch(() => {})
+
+  // The cached entitlement is the only asynchronous decision that must precede the shell. It is
+  // local and fail-closed: if it misses the bound, Pro stays unavailable until the provider lands.
+  await runStartupStage({
+    name: 'pro.entitlement.load-cached',
+    deadlineMs: 5_000,
+    required: true,
+    lateEffect: 'keep',
+    run: () => loadProEntitlementProvider()
+  })
+  initLicensing()
+  setupLicenseIpc()
+  const entitlementRefresh = setInterval(() => {
+    refreshCachedProEntitlement()
+    void revalidateProEntitlement('foreground')
+  }, PERSONAL_MESH_ENTITLEMENT_REVALIDATION_INTERVAL_MS)
+  entitlementRefresh.unref()
+  applicationShutdown.register({
+    name: 'pro:entitlement-refresh',
+    shutdown: () => clearInterval(entitlementRefresh)
+  })
+
+  await runStartupStage({
+    name: 'core.ipc',
+    deadlineMs: 10_000,
+    required: true,
+    lateEffect: 'guard',
+    run: ({ commit }) =>
+      commit('core.ipc.handlers', () => {
+        setupIPC()
+        setupRagIPC()
+        setupMcpIpc()
+        registerNativeActionTools(registerToolExtension)
+        setupDesktopBackupIPC()
+        ipcMain.handle('media:url', (_event, absPath: string) => mediaUrlFor(absPath))
+      })
+  })
+
+  // These registrations are independent. They load together, and each failure remains isolated.
+  await runIndependentStartupStages([
+    {
+      name: 'actions.ipc',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./actions/actions-ipc').then((module) =>
+          commit('actions.ipc.handlers', module.registerActionsIpc)
+        )
+    },
+    {
+      name: 'browser.view.ipc',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./browser/browser-host').then((module) =>
+          commit('browser.view.ipc.handlers', module.registerBrowserViewIpc)
+        )
+    },
+    {
+      name: 'vision.ipc',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./vision/vision-controller').then((module) =>
+          commit('vision.ipc.handlers', module.registerVisionIpc)
+        )
+    },
+    {
+      name: 'vision.supervisor-window',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./vision/supervisor-window').then((module) =>
+          commit('vision.supervisor-window.handlers', module.registerSupervisorWindowIpc)
+        )
+    },
+    {
+      name: 'tasks.history.ipc',
+      deadlineMs: 10_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./tasks/task-history-ipc').then((module) =>
+          commit('tasks.history.ipc.handlers', module.registerTaskHistoryIpc)
+        )
+    }
+  ])
 
   createWindow()
 
-  // Update IPC is always registered (the renderer queries staged-version on startup
-  // in every build); the auto-download engine runs production-only (dev has no feed).
-  import('./updater')
-    .then((m) => {
-      m.registerUpdateIpc()
-      if (!is.dev) m.startAutoUpdates()
-    })
-    .catch((e) => console.error('[update] init', e))
+  // Network checks, model work, and optional services now run beside the visible shell.
+  void runIndependentStartupStages([
+    {
+      name: 'pro.entitlement.revalidate',
+      deadlineMs: 30_000,
+      lateEffect: 'keep',
+      run: () => revalidateProEntitlement('launch')
+    },
+    {
+      name: 'models.gateway.start',
+      deadlineMs: 30_000,
+      lateEffect: 'keep',
+      run: () => startModelServer()
+    },
+    {
+      name: 'media.server.start',
+      deadlineMs: 10_000,
+      lateEffect: 'keep',
+      run: () => startMediaServer()
+    },
+    {
+      name: 'models.text.prepare',
+      deadlineMs: 180_000,
+      lateEffect: 'keep',
+      run: async () => {
+        const { llm } = await import('./llm')
+        registerRuntime(llm.runtime)
+        applyQueueConfig(modalityQueue, readQueueConfig(getSetting))
+        if (llm.modelsExist()) await llm.init()
+      }
+    },
+    {
+      name: 'modalities.runtime.register',
+      deadlineMs: 30_000,
+      lateEffect: 'guard',
+      run: async ({ commit }) => {
+        const [{ ttsRuntime }, { imageRuntime }, { sttRuntime }] = await Promise.all([
+          import('./tts'),
+          import('./imagegen'),
+          import('./transcription/select')
+        ])
+        commit('modalities.runtime.registrations', () => {
+          registerRuntime(ttsRuntime)
+          registerRuntime(imageRuntime)
+          registerRuntime(sttRuntime)
+        })
+      }
+    },
+    {
+      name: 'models.projector.reconcile',
+      deadlineMs: 15_000,
+      lateEffect: 'keep',
+      run: () => import('./models-manager').then((module) => module.reconcileActiveModelProjector())
+    },
+    {
+      name: 'pro.features.load',
+      deadlineMs: 30_000,
+      lateEffect: 'keep',
+      run: () => loadProFeaturesMain()
+    },
+    {
+      name: 'updater.ipc',
+      deadlineMs: 15_000,
+      lateEffect: 'guard',
+      run: ({ commit }) =>
+        import('./updater').then((module) =>
+          commit('updater.ipc.handlers', () => {
+            module.registerUpdateIpc()
+            if (!is.dev) module.startAutoUpdates()
+          })
+        )
+    }
+  ])
+
+  // Demo seeding already runs beside the shell. Keep its existing persistence semantics instead of
+  // pretending an in-progress database write can be cancelled by a timer.
+  if (process.env.OFFGRID_SEED) {
+    void import('./dev-seed')
+      .then((module) => module.seedDemo(process.env.OFFGRID_SEED === 'force'))
+      .catch((error) => console.error('[seed]', error))
+  }
 
   app.on('activate', function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()

--- a/src/main/media-server.ts
+++ b/src/main/media-server.ts
@@ -195,13 +195,13 @@ function serveFile(req: http.IncomingMessage, res: http.ServerResponse, filePath
   rs.pipe(res)
 }
 
-/** Start the loopback media server (idempotent). Call after app is ready. */
-export function startMediaServer(): void {
+/** Start the loopback media server (idempotent). Resolves only after the socket is ready. */
+export function startMediaServer(): Promise<void> {
   productionServer ??= new LoopbackMediaServer({
     roots: localMediaRoots(app.getPath('userData'), resourceDirs()),
     port: MEDIA_PORT
   })
-  void productionServer.start().catch((error) => console.error('[media-server]', error))
+  return productionServer.start()
 }
 
 /** Build a loopback URL only after the production socket is ready. */

--- a/src/main/models-manager.ts
+++ b/src/main/models-manager.ts
@@ -41,7 +41,11 @@ import {
   type VisionStatus
 } from './models/catalog-logic'
 import { writeDiagnosticLog } from './diagnostics-log'
-import { modelPackageIdentity, type TransferredModelManifest } from '@offgrid/sync'
+import {
+  modelPackageIdentity,
+  modelTransferManifestFileError,
+  type TransferredModelManifest
+} from '@offgrid/sync'
 import { sampleProgressRate, type ProgressRateSample } from '@offgrid/ui'
 import {
   parseRemoteVisionModelId,
@@ -938,33 +942,14 @@ function saveLocalModels(list: LocalModel[], dir = llm.getModelsDir()): void {
   }
 }
 
-function safeTransferredFileName(name: string): boolean {
-  return (
-    name.length > 0 &&
-    name.length <= 255 &&
-    path.basename(name) === name &&
-    name !== '.' &&
-    name !== '..'
-  )
-}
-
 function transferredFilesOnDisk(
   dir: string,
   files: Array<{ name: string; sizeBytes: number }>
 ): { error?: string; files?: TransferableModelFile[] } {
-  if (files.length === 0) return { error: 'model has no transferable files' }
-  const names = new Set<string>()
+  const manifestError = modelTransferManifestFileError(files)
+  if (manifestError) return { error: manifestError }
   const resolved: TransferableModelFile[] = []
   for (const file of files) {
-    if (
-      !safeTransferredFileName(file.name) ||
-      !Number.isSafeInteger(file.sizeBytes) ||
-      file.sizeBytes <= 0 ||
-      names.has(file.name)
-    ) {
-      return { error: 'model manifest contains an invalid file' }
-    }
-    names.add(file.name)
     const filePath = path.join(dir, file.name)
     let actualSize = 0
     try {

--- a/src/main/rag-ipc.ts
+++ b/src/main/rag-ipc.ts
@@ -6,6 +6,7 @@ import fs from 'fs'
 import { randomUUID } from 'node:crypto'
 import { ragService, listProjects, createProject, updateProject, deleteProject } from './rag'
 import { uploadPickerExtensions } from './files-classify'
+import { projectDeleteFailure, type ProjectDeleteOutcome } from '../shared/project-delete-outcome'
 
 // Built from the router's classify sets (files-classify) so the picker allowlist
 // and the processor can never drift: it used to hardcode a subset that omitted
@@ -29,7 +30,16 @@ export function setupRagIPC(): void {
     updateProject(id, patch)
   })
 
-  ipcMain.handle('projects:delete', (_e, id: string) => deleteProject(id))
+  ipcMain.handle('projects:delete', (_e, id: string): ProjectDeleteOutcome => {
+    try {
+      // The RAG store owns one transaction for the project, its documents, and its chat links.
+      // Report that transaction's result before the renderer drops its local projection.
+      deleteProject(id)
+      return { ok: true }
+    } catch (error) {
+      return projectDeleteFailure(error)
+    }
+  })
 
   // --- Knowledge base (documents) ------------------------------------------
   ipcMain.handle('projects:list-documents', (_e, projectId: string) =>

--- a/src/main/startup-ipc.ts
+++ b/src/main/startup-ipc.ts
@@ -1,0 +1,21 @@
+import { BrowserWindow, ipcMain } from 'electron'
+import { startupProjection } from './startup-projection'
+
+const STARTUP_STATUS_CHANNEL = 'app:startup-status'
+const STARTUP_STATUS_CHANGED_CHANNEL = 'app:startup-status-changed'
+
+export function registerStartupStatusIpc(): () => void {
+  ipcMain.handle(STARTUP_STATUS_CHANNEL, () => startupProjection.snapshot())
+  const unsubscribe = startupProjection.subscribe((snapshot) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send(STARTUP_STATUS_CHANGED_CHANNEL, snapshot)
+      }
+    }
+  })
+
+  return () => {
+    unsubscribe()
+    ipcMain.removeHandler(STARTUP_STATUS_CHANNEL)
+  }
+}

--- a/src/main/startup-projection.ts
+++ b/src/main/startup-projection.ts
@@ -1,0 +1,64 @@
+import type {
+  StartupPhase,
+  StartupSnapshot,
+  StartupStageSnapshot
+} from '../shared/startup-contract'
+
+export interface StartupProjection {
+  snapshot(): StartupSnapshot
+  subscribe(listener: (snapshot: StartupSnapshot) => void): () => void
+  stageStarted(stage: { readonly name: string; readonly required: boolean }): void
+  stageSettled(stage: StartupStageSnapshot): void
+}
+
+function phaseFor(stages: readonly StartupStageSnapshot[]): StartupPhase {
+  const failed = (stage: StartupStageSnapshot): boolean =>
+    stage.status === 'failed' || stage.status === 'timeout'
+
+  if (stages.some((stage) => stage.required && failed(stage))) return 'failed'
+  if (stages.some((stage) => stage.status === 'running')) return 'pending'
+  if (stages.some((stage) => failed(stage) || stage.status === 'late')) return 'degraded'
+  return stages.length > 0 ? 'ready' : 'pending'
+}
+
+export function createStartupProjection(): StartupProjection {
+  const stages = new Map<string, StartupStageSnapshot>()
+  const listeners = new Set<(snapshot: StartupSnapshot) => void>()
+  let revision = 0
+  let current: StartupSnapshot = {
+    revision,
+    phase: 'pending',
+    running: [],
+    stages: []
+  }
+
+  const publish = (): void => {
+    const reports = [...stages.values()]
+    revision += 1
+    current = {
+      revision,
+      phase: phaseFor(reports),
+      running: reports.filter((stage) => stage.status === 'running').map((stage) => stage.name),
+      stages: reports
+    }
+    for (const listener of listeners) listener(current)
+  }
+
+  return {
+    snapshot: () => current,
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    stageStarted: ({ name, required }) => {
+      stages.set(name, { name, status: 'running', required })
+      publish()
+    },
+    stageSettled: (stage) => {
+      stages.set(stage.name, stage)
+      publish()
+    }
+  }
+}
+
+export const startupProjection = createStartupProjection()

--- a/src/main/startup-stages.ts
+++ b/src/main/startup-stages.ts
@@ -1,0 +1,176 @@
+import { writeDiagnosticLog } from './diagnostics-log'
+import { startupProjection } from './startup-projection'
+
+export type StartupStageResult<T> =
+  | { readonly ok: true; readonly value: T; readonly durationMs: number }
+  | {
+      readonly ok: false
+      readonly reason: 'failed' | 'timeout'
+      readonly error: string
+      readonly durationMs: number
+    }
+
+export interface StartupStageContext {
+  readonly signal: AbortSignal
+  isOwner(): boolean
+  commit<R>(label: string, apply: () => R): R | undefined
+}
+
+interface StartupStageBase<T> {
+  readonly name: string
+  readonly deadlineMs: number
+  readonly required?: boolean
+  readonly run: (context: StartupStageContext) => Promise<T> | T
+}
+
+export type StartupStage<T> = StartupStageBase<T> &
+  (
+    | { readonly lateEffect: 'keep' }
+    | {
+        readonly lateEffect: 'guard'
+        readonly run: (context: StartupStageContext) => Promise<T> | T
+      }
+  )
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function settleFailure<T>(input: {
+  readonly stage: StartupStage<T>
+  readonly reason: 'failed' | 'timeout'
+  readonly error: string
+  readonly durationMs: number
+}): StartupStageResult<T> {
+  const { stage, reason, error, durationMs } = input
+  writeDiagnosticLog(
+    'startup',
+    reason === 'timeout' ? 'stage.timeout' : 'stage.failed',
+    { stage: stage.name, durationMs, error },
+    'error'
+  )
+  startupProjection.stageSettled({
+    name: stage.name,
+    status: reason,
+    required: stage.required === true,
+    durationMs,
+    error
+  })
+  return { ok: false, reason, error, durationMs }
+}
+
+export async function runStartupStage<T>(stage: StartupStage<T>): Promise<StartupStageResult<T>> {
+  const startedAt = Date.now()
+  const required = stage.required === true
+  const controller = new AbortController()
+  let owned = true
+  let commitsApplied = 0
+  let commitsRefused = 0
+  let timer: NodeJS.Timeout | undefined
+
+  startupProjection.stageStarted({ name: stage.name, required })
+
+  const context: StartupStageContext = {
+    signal: controller.signal,
+    isOwner: () => owned,
+    commit: <R>(label: string, apply: () => R): R | undefined => {
+      if (owned) {
+        commitsApplied += 1
+        return apply()
+      }
+      commitsRefused += 1
+      writeDiagnosticLog(
+        'startup',
+        'stage.late-commit-refused',
+        { stage: stage.name, change: label },
+        'error'
+      )
+      return undefined
+    }
+  }
+
+  const work = Promise.resolve().then(() => stage.run(context))
+  const deadline = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => {
+      owned = false
+      controller.abort()
+      resolve('timeout')
+    }, stage.deadlineMs)
+    timer.unref()
+  })
+
+  try {
+    const outcome = await Promise.race([work.then((value) => ({ value }) as const), deadline])
+    const durationMs = Date.now() - startedAt
+    if (outcome === 'timeout') {
+      void work.then(
+        () => {
+          const lateDurationMs = Date.now() - startedAt
+          const kept = stage.lateEffect === 'keep'
+          const effect = kept ? 'kept' : commitsRefused > 0 ? 'guarded' : 'no-guarded-change'
+          writeDiagnosticLog(
+            'startup',
+            'stage.late-completion',
+            {
+              stage: stage.name,
+              durationMs: lateDurationMs,
+              effect,
+              commitsApplied,
+              commitsRefused
+            },
+            'warn'
+          )
+          if (kept) {
+            startupProjection.stageSettled({
+              name: stage.name,
+              status: 'late',
+              required,
+              durationMs: lateDurationMs,
+              error: `settled ${lateDurationMs - stage.deadlineMs}ms after its deadline`
+            })
+          }
+        },
+        (error: unknown) => {
+          writeDiagnosticLog(
+            'startup',
+            'stage.late-failure',
+            { stage: stage.name, durationMs: Date.now() - startedAt, error: describe(error) },
+            'error'
+          )
+        }
+      )
+      return settleFailure({
+        stage,
+        reason: 'timeout',
+        error: `exceeded ${stage.deadlineMs}ms`,
+        durationMs
+      })
+    }
+
+    owned = false
+    writeDiagnosticLog('startup', 'stage.completed', { stage: stage.name, durationMs })
+    startupProjection.stageSettled({
+      name: stage.name,
+      status: 'completed',
+      required,
+      durationMs
+    })
+    return { ok: true, value: outcome.value, durationMs }
+  } catch (error) {
+    owned = false
+    return settleFailure({
+      stage,
+      reason: 'failed',
+      error: describe(error),
+      durationMs: Date.now() - startedAt
+    })
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+export function runIndependentStartupStages(
+  stages: readonly StartupStage<unknown>[]
+): Promise<readonly StartupStageResult<unknown>[]> {
+  return Promise.all(stages.map((stage) => runStartupStage(stage)))
+}

--- a/src/main/tools.ts
+++ b/src/main/tools.ts
@@ -8,6 +8,7 @@
 
 import { llm } from './llm'
 import { SEARCH_KB_TOOL, makeSearchKnowledgeBaseHandler } from '@offgrid/rag'
+import { stripChatControlTokens } from '@offgrid/sync'
 import { isMemoryToolAllowed } from './tools/memory-scope'
 import { parseToolCallsFromText } from './tools/tool-call-parse'
 import { getSetting, saveSetting } from './database'
@@ -30,6 +31,7 @@ import {
   callsWithinToolBudget,
   finalResponseFromToolResults,
   normalizeMaxToolCalls,
+  toolLimitFinalAnswerInstruction,
   toolPromptChars,
   toolResultCharBudget
 } from '@offgrid/models'
@@ -708,8 +710,9 @@ export async function toolChat(
   const settings = llm.getSettings()
   const maxToolCalls = normalizeMaxToolCalls(settings.maxToolCalls)
   const answerFrom = (content: string): string => {
-    const answer = finalResponseFromToolResults(content, successfulToolResults)
-    if (!content.trim() && answer) onDelta(answer, 'content')
+    const visibleContent = stripChatControlTokens(content)
+    const answer = finalResponseFromToolResults(visibleContent, successfulToolResults)
+    if (!visibleContent && answer) onDelta(answer, 'content')
     return answer
   }
   let round = 0
@@ -823,7 +826,11 @@ export async function toolChat(
   if (opts.signal?.aborted) {
     return resultWithImages({ answer: '', toolCalls, unified })
   }
-  const final = await llm.streamChat(messages, onDelta, {
+  const finalMessages = [
+    { role: 'system', content: toolLimitFinalAnswerInstruction(maxToolCalls) },
+    ...messages.filter((message) => message.role !== 'system')
+  ]
+  const final = await llm.streamChat(finalMessages, onDelta, {
     temperature: 0.3,
     // Forced final answer — inherit the user's Max-output setting (auto by default), never a fixed
     // 1024 cap that truncated the response mid-sentence.

--- a/src/main/tools.ts
+++ b/src/main/tools.ts
@@ -25,7 +25,14 @@ import {
 } from './proposal-deck/tool'
 import { proposalDeckSystemHint, proposalDeckService } from './proposal-deck/service'
 import { callHookAsync, HOOKS } from './bootstrap/hookRegistry'
-import { DEFAULT_MAX_TOOL_CALLS } from '../shared/llm-defaults'
+import {
+  boundToolResult,
+  callsWithinToolBudget,
+  finalResponseFromToolResults,
+  normalizeMaxToolCalls,
+  toolPromptChars,
+  toolResultCharBudget
+} from '@offgrid/models'
 
 // Per-tool enable/disable, persisted as a list of disabled tool names.
 function disabledSet(): Set<string> {
@@ -672,6 +679,7 @@ export async function toolChat(
     { role: 'user', content: buildContentParts(query, decodedImages) }
   ]
   const toolCalls: ToolCall[] = []
+  const successfulToolResults: string[] = []
   const unified: UnifiedSource[] = []
   const unifiedKeys = new Set<string>()
   // Deferred image generation: keep EVERY request in tool-call order. The renderer generates after
@@ -697,7 +705,13 @@ export async function toolChat(
     }
   }
 
-  const maxToolCalls = llm.getSettings().maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS
+  const settings = llm.getSettings()
+  const maxToolCalls = normalizeMaxToolCalls(settings.maxToolCalls)
+  const answerFrom = (content: string): string => {
+    const answer = finalResponseFromToolResults(content, successfulToolResults)
+    if (!content.trim() && answer) onDelta(answer, 'content')
+    return answer
+  }
   let round = 0
   while (toolCalls.length < maxToolCalls) {
     // Stream this round: reasoning + any answer text flow through onDelta live; tool_calls
@@ -744,8 +758,7 @@ export async function toolChat(
     if (effective.length) {
       // One model round can request several tools in parallel. Count the actual calls, as Mobile
       // does, and execute only the remaining allowance so the configured ceiling stays truthful.
-      const remaining = maxToolCalls - toolCalls.length
-      const callsToRun = effective.slice(0, remaining)
+      const callsToRun = callsWithinToolBudget(effective, toolCalls.length, maxToolCalls)
       // Re-add the assistant turn (with its tool_calls) so the model sees what it invoked.
       messages.push({
         role: 'assistant',
@@ -769,7 +782,16 @@ export async function toolChat(
         // Uniform dispatch — every tool owns its own result. Merge any structured
         // side channels: sources are deduped into `unified` across rounds; image requests retain
         // call order for deferred generation after the turn.
-        const res = await runTool(c.name, c.args, toolContext, exts)
+        const rawResult = await runTool(c.name, c.args, toolContext, exts)
+        const resultBudget = toolResultCharBudget({
+          contextLength: llm.effectiveContextSize(),
+          promptChars: toolPromptChars(messages, tools),
+          replyReserveTokens: settings.maxTokens
+        })
+        const res = {
+          ...rawResult,
+          text: boundToolResult(c.name, rawResult.text, resultBudget)
+        }
         for (const s of res.sources ?? []) {
           if (unifiedKeys.has(s.key)) continue
           unifiedKeys.add(s.key)
@@ -778,6 +800,7 @@ export async function toolChat(
         if (res.imageRequests?.length) imageRequests.push(...res.imageRequests)
         else if (res.imageRequest) imageRequests.push(res.imageRequest)
         const status = res.status ?? 'completed'
+        if (status === 'completed' && res.text.trim()) successfulToolResults.push(res.text)
         toolCalls.push({ name: c.name, args: c.args, result: res.text, status })
         // Surface the COMPLETED call (with its result) live, so the UI can show each
         // tool call + result as it lands, not only in the final batch.
@@ -792,7 +815,7 @@ export async function toolChat(
       continue // let the model use the results
     }
     // No tool calls this round: `content` is the final answer (already streamed via onDelta).
-    return resultWithImages({ answer: content.trim(), toolCalls, unified })
+    return resultWithImages({ answer: answerFrom(content), toolCalls, unified })
   }
   // The configured emergency cap was reached with the model still calling tools. Instead of dead-ending
   // with a canned "stopped" message, FORCE one final answer WITHOUT tools, so the
@@ -808,7 +831,7 @@ export async function toolChat(
     signal: opts.signal
   })
   return resultWithImages({
-    answer: final.content.trim() || 'Stopped after too many tool steps.',
+    answer: answerFrom(final.content) || 'Stopped after too many tool steps.',
     toolCalls,
     unified
   })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -28,6 +28,7 @@ import type {
 import type { TaskGuideInput } from '../shared/task-guidance'
 import type { RemoteVisionServerUpdate } from '../shared/remote-vision-server'
 import type { StartupSnapshot } from '../shared/startup-contract'
+import type { ProjectDeleteOutcome } from '../shared/project-delete-outcome'
 import type { TaskRunSnapshot } from '../main/tasks/task-history-store'
 
 console.log('PRELOAD SCRIPT LOADED')
@@ -771,7 +772,8 @@ const offGridApi = {
   }) => ipcRenderer.invoke('projects:create', p),
   updateProject: (id: string, patch: Record<string, unknown>) =>
     ipcRenderer.invoke('projects:update', id, patch),
-  deleteProject: (id: string) => ipcRenderer.invoke('projects:delete', id),
+  deleteProject: (id: string) =>
+    ipcRenderer.invoke('projects:delete', id) as Promise<ProjectDeleteOutcome>,
   listProjectDocuments: (projectId: string) =>
     ipcRenderer.invoke('projects:list-documents', projectId),
   addProjectDocuments: (projectId: string) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -27,6 +27,7 @@ import type {
 } from '../shared/browser-session'
 import type { TaskGuideInput } from '../shared/task-guidance'
 import type { RemoteVisionServerUpdate } from '../shared/remote-vision-server'
+import type { StartupSnapshot } from '../shared/startup-contract'
 import type { TaskRunSnapshot } from '../main/tasks/task-history-store'
 
 console.log('PRELOAD SCRIPT LOADED')
@@ -511,6 +512,13 @@ const offGridApi = {
     ): void => callback(data)
     ipcRenderer.on('model:download-progress', subscription)
     return unsubscribe('model:download-progress', subscription)
+  },
+
+  startupStatus: (): Promise<StartupSnapshot> => ipcRenderer.invoke('app:startup-status'),
+  onStartupStatusChanged: (callback: (snapshot: StartupSnapshot) => void) => {
+    const subscription = (_event: unknown, snapshot: StartupSnapshot): void => callback(snapshot)
+    ipcRenderer.on('app:startup-status-changed', subscription)
+    return unsubscribe('app:startup-status-changed', subscription)
   },
 
   // Setup + system health

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -67,6 +67,7 @@ import { navigateSearchHit } from './lib/search-navigation'
 import { internalTabPaletteScreens } from './lib/paletteScreens'
 import { getSlot, SLOTS } from './bootstrap/slotRegistry'
 import { SidebarNavigationMenu } from './components/navigation/SidebarNavigationMenu'
+import { StartupNotice } from './components/StartupNotice'
 import { CHAT_VIEW, setCurrentView } from './lib/current-view'
 import {
   OPEN_MODEL_SETTINGS_PANEL_EVENT,
@@ -1045,6 +1046,7 @@ function AppContent() {
 
   return (
     <div className="h-screen w-full overflow-hidden bg-neutral-950 relative">
+      <StartupNotice />
       <CommandPalette
         onOpenHit={handleOpenHit}
         onSeeAll={openSearch}

--- a/src/renderer/src/components/MemoryChat.tsx
+++ b/src/renderer/src/components/MemoryChat.tsx
@@ -668,6 +668,8 @@ function standardMessageRowClass(message: ChatMessage): string {
   return `${margin} flex flex-col ${alignment}`
 }
 
+const IMAGE_MESSAGE_COLUMN_WIDTH = 'w-full max-w-2xl'
+
 function standardMessageBubbleClass(message: ChatMessage, editing: boolean): string {
   const emptyAssistant =
     message.role === 'assistant' &&
@@ -681,7 +683,9 @@ function standardMessageBubbleClass(message: ChatMessage, editing: boolean): str
   // as its prompt - some 1700px on a maximised window - and a picture told to fill that width was
   // gigantic. The same cap makes the two kinds of picture behave the same way.
   const width =
-    editing || message.image || message.attachments?.length ? 'w-full max-w-2xl' : 'max-w-[85%]'
+    editing || message.image || message.attachments?.length
+      ? IMAGE_MESSAGE_COLUMN_WIDTH
+      : 'max-w-[85%]'
   const color = message.context?.taskGuidance
     ? 'border border-green-500/50 bg-green-500/5 text-foreground'
     : message.role === 'user'
@@ -1984,6 +1988,7 @@ function MessageBubble({
           path={message.imagePath}
           metadata={message.imageMetadata}
           className="mb-2 w-full max-w-full cursor-zoom-in rounded-md border border-neutral-800 object-contain transition-opacity hover:opacity-90"
+          fill
           onOpen={actions.openImage}
         />
       ) : null}
@@ -5427,11 +5432,13 @@ export function MemoryChat({
                             />
                           ) : null}
                           {mode === 'image' ? (
-                            <StylePresetPicker
-                              activeStyle={activeStyle}
-                              styleThumbs={styleThumbs}
-                              onChange={setActiveStyle}
-                            />
+                            showImageOptions ? (
+                              <StylePresetPicker
+                                activeStyle={activeStyle}
+                                styleThumbs={styleThumbs}
+                                onChange={setActiveStyle}
+                              />
+                            ) : null
                           ) : (
                             <div className="mt-6 grid w-full grid-cols-1 gap-2 sm:grid-cols-2">
                               {examples.map((ex) => (
@@ -5513,7 +5520,9 @@ export function MemoryChat({
                             Off Grid AI
                           </div>
                           {mode === 'image' || generatingImage ? (
-                            <div className="flex w-full flex-col items-start gap-2">
+                            <div
+                              className={`flex ${IMAGE_MESSAGE_COLUMN_WIDTH} flex-col items-start gap-2`}
+                            >
                               {imageJobStage === 'enhancing' || streamingEnhancedPrompt ? (
                                 <ChatThinkingBlock
                                   content={streamingEnhancedPrompt || 'Starting…'}
@@ -5715,7 +5724,7 @@ export function MemoryChat({
                     )}
 
                     <AnimatePresence initial={false}>
-                      {mode === 'image' && messages.length > 0 ? (
+                      {mode === 'image' && showImageOptions && messages.length > 0 ? (
                         <motion.div
                           key="inline-image-style-picker"
                           role="region"

--- a/src/renderer/src/components/ProjectsScreen.tsx
+++ b/src/renderer/src/components/ProjectsScreen.tsx
@@ -19,6 +19,10 @@ import { ArtifactCanvas, type Artifact } from './ArtifactCanvas'
 import { artifactKindLabel } from '@renderer/lib/artifact-labels'
 import { timeAgo } from '@renderer/lib/time'
 import { useRendererEntitlement } from '@renderer/bootstrap/useRendererEntitlement'
+import {
+  PROJECT_DELETE_FALLBACK_REASON,
+  type ProjectDeleteOutcome
+} from '../../../shared/project-delete-outcome'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const api = (window as any).api
@@ -133,6 +137,7 @@ export function ProjectsScreen({
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
   const [view, setView] = useState<'chat' | 'artifacts' | 'config'>('chat')
+  const [deleteFailure, setDeleteFailure] = useState('')
 
   const refreshProjects = useCallback(async () => {
     const list = (await api.listProjects?.()) ?? []
@@ -176,7 +181,12 @@ export function ProjectsScreen({
     ) {
       return
     }
-    await api.deleteProject?.(id)
+    setDeleteFailure('')
+    const outcome = (await api.deleteProject?.(id)) as ProjectDeleteOutcome | undefined
+    if (!outcome?.ok) {
+      setDeleteFailure(outcome?.reason || PROJECT_DELETE_FALLBACK_REASON)
+      return
+    }
     selectProject(null)
     await refreshProjects()
   }
@@ -195,6 +205,11 @@ export function ProjectsScreen({
             <IconPlus className="h-4 w-4" />
           </button>
         </div>
+        {deleteFailure ? (
+          <p role="alert" className="mx-4 mb-2 text-[11px] text-red-400">
+            {deleteFailure}
+          </p>
+        ) : null}
         <div className="flex-1 overflow-y-auto px-2">
           {creating && (
             <input

--- a/src/renderer/src/components/StartupNotice.tsx
+++ b/src/renderer/src/components/StartupNotice.tsx
@@ -1,0 +1,108 @@
+import { WarningCircle } from '@phosphor-icons/react'
+import { useCallback, useEffect, useState } from 'react'
+import type { StartupSnapshot } from '../../../shared/startup-contract'
+import { LoadingDots } from './ui/loading-dots'
+
+const STAGE_LABELS: Readonly<Record<string, string>> = {
+  'pro.entitlement.load-cached': 'Checking your license',
+  'core.ipc': 'Starting Off Grid AI Desktop',
+  'actions.ipc': 'Starting actions',
+  'browser.view.ipc': 'Starting Web Use',
+  'vision.ipc': 'Starting Computer Use',
+  'vision.supervisor-window': 'Starting Computer Use',
+  'tasks.history.ipc': 'Opening your tasks',
+  'pro.entitlement.revalidate': 'Confirming your license',
+  'models.gateway.start': 'Starting the local API',
+  'media.server.start': 'Preparing media playback',
+  'models.text.prepare': 'Loading your model',
+  'modalities.runtime.register': 'Preparing local models',
+  'models.projector.reconcile': 'Checking your models',
+  'pro.features.load': 'Starting Pro features',
+  'updater.ipc': 'Checking for updates'
+}
+
+function labelFor(stageName: string | undefined): string | undefined {
+  return stageName ? STAGE_LABELS[stageName] : undefined
+}
+
+function pendingText(snapshot: StartupSnapshot): string {
+  return labelFor(snapshot.running[0]) ?? 'Starting Off Grid AI Desktop'
+}
+
+function degradedText(snapshot: StartupSnapshot): string {
+  const failed = snapshot.stages.find(
+    (stage) => stage.status === 'failed' || stage.status === 'timeout'
+  )
+  const failedLabel = labelFor(failed?.name)
+  if (failedLabel) return `${failedLabel} did not finish. The rest of the app is ready.`
+
+  const late = snapshot.stages.find((stage) => stage.status === 'late')
+  const lateLabel = labelFor(late?.name)
+  return lateLabel
+    ? `${lateLabel} took longer than expected, but it is ready.`
+    : 'Part of the app took longer than expected, but it is ready.'
+}
+
+export function StartupNotice(): React.JSX.Element | null {
+  const [snapshot, setSnapshot] = useState<StartupSnapshot | null>(null)
+  const applySnapshot = useCallback((next: StartupSnapshot): void => {
+    setSnapshot((current) => (!current || next.revision >= current.revision ? next : current))
+  }, [])
+
+  useEffect(() => {
+    let mounted = true
+    const unsubscribe = window.api.onStartupStatusChanged((next) => {
+      if (mounted) applySnapshot(next)
+    })
+    void window.api
+      .startupStatus()
+      .then((next) => {
+        if (mounted) applySnapshot(next)
+      })
+      .catch(() => {})
+
+    return () => {
+      mounted = false
+      unsubscribe()
+    }
+  }, [applySnapshot])
+
+  if (!snapshot || snapshot.phase === 'ready') return null
+
+  if (snapshot.phase === 'failed') {
+    return (
+      <div
+        role="status"
+        aria-live="assertive"
+        className="pointer-events-none absolute inset-x-0 top-0 z-50 flex items-center justify-center gap-2 bg-red-950/90 px-4 py-1.5 font-mono text-[11px] text-red-200"
+      >
+        <WarningCircle size={13} weight="bold" aria-hidden />
+        <span>Off Grid AI Desktop could not finish startup. Restart the app.</span>
+      </div>
+    )
+  }
+
+  if (snapshot.phase === 'degraded') {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="pointer-events-none absolute inset-x-0 top-0 z-50 flex items-center justify-center gap-2 bg-amber-950/80 px-4 py-1.5 font-mono text-[11px] text-amber-200"
+      >
+        <WarningCircle size={13} aria-hidden />
+        <span>{degradedText(snapshot)}</span>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none absolute inset-x-0 top-0 z-50 flex items-center justify-center gap-2 bg-neutral-900/85 px-4 py-1.5 font-mono text-[11px] text-neutral-400"
+    >
+      <span>{pendingText(snapshot)}</span>
+      <LoadingDots size="small" />
+    </div>
+  )
+}

--- a/src/renderer/src/components/__tests__/MemoryChat.image.test.tsx
+++ b/src/renderer/src/components/__tests__/MemoryChat.image.test.tsx
@@ -440,7 +440,10 @@ describe('<MemoryChat/> image mode — the generateImage payload is the terminal
     })
     renderChat()
 
-    await openImageComposer(user)
+    await user.click(await screen.findByRole('button', { name: /^image$/i }))
+    expect(screen.queryByAltText('Photoreal')).toBeNull()
+    const imageOptions = await screen.findByRole('button', { name: /image options/i })
+    await user.click(imageOptions)
 
     expect((await screen.findByAltText('Photoreal')).getAttribute('src')).toBe(
       'ogcapture:///app/resources/style-thumbs/Photoreal.png'
@@ -450,6 +453,16 @@ describe('<MemoryChat/> image mode — the generateImage payload is the terminal
       'ogcapture:///app/resources/style-thumbs/Cinematic.png'
     )
     expect(screen.queryByRole('button', { name: /generate previews/i })).toBeNull()
+
+    const photoreal = screen.getByAltText('Photoreal').closest('button')!
+    await user.click(photoreal)
+    expect(photoreal.getAttribute('aria-pressed')).toBe('true')
+    await user.click(imageOptions)
+    expect(screen.queryByAltText('Photoreal')).toBeNull()
+    await user.click(imageOptions)
+    expect(screen.getByAltText('Photoreal').closest('button')?.getAttribute('aria-pressed')).toBe(
+      'true'
+    )
   })
 
   it('shows the same style previews inline when Image is opened in an existing chat', async () => {
@@ -477,7 +490,9 @@ describe('<MemoryChat/> image mode — the generateImage payload is the terminal
     renderChat({ conversationId: conv.id })
 
     expect(await screen.findByText('Draw a dog')).toBeTruthy()
-    await openImageComposer(user)
+    await user.click(await screen.findByRole('button', { name: /^image$/i }))
+    expect(screen.queryByRole('region', { name: 'Image style presets' })).toBeNull()
+    await user.click(await screen.findByRole('button', { name: /image options/i }))
 
     expect((await screen.findByAltText('Photoreal')).getAttribute('src')).toBe(
       'ogcapture:///app/resources/style-thumbs/Photoreal.png'
@@ -1008,7 +1023,10 @@ describe('<MemoryChat/> image and vision release journeys', () => {
     act(() => {
       boundary.emitProgress({ phase: 'sampling', step: 4, total: 10, secPerStep: 0.5 })
     })
-    expect(await screen.findByText('Generating image · Step 4 of 10')).toBeTruthy()
+    const progressLabel = await screen.findByText('Generating image · Step 4 of 10')
+    const progressColumn = progressLabel.closest('.max-w-2xl')
+    expect(progressColumn?.className).toContain('w-full')
+    expect(progressColumn?.className).toContain('max-w-2xl')
 
     const enhancedPrompt =
       'A cinematic lighthouse in a fierce winter storm, dramatic waves, cold blue light'
@@ -1022,6 +1040,7 @@ describe('<MemoryChat/> image and vision release journeys', () => {
     const disclosure = await screen.findByRole('button', { name: /enhanced prompt/i })
     expect(screen.getAllByAltText('Generated')).toHaveLength(1)
     expect(generated.className).toContain('w-full')
+    expect(generated.closest('button')?.className).toContain('w-full')
     expect(generated.compareDocumentPosition(caption) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(
       0
     )

--- a/src/renderer/src/components/__tests__/ProjectsScreen.delete-refusal.integration.test.tsx
+++ b/src/renderer/src/components/__tests__/ProjectsScreen.delete-refusal.integration.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RendererEntitlementProvider } from '../../bootstrap/RendererEntitlementProvider'
+import { installAppBoundary } from '../../__tests__/harness/app-boundary'
+
+const project = {
+  id: 'protected-project',
+  name: 'Protected project',
+  description: '',
+  systemPrompt: '',
+  includeMemory: false,
+  updatedAt: '2026-09-11T00:00:00.000Z'
+}
+
+describe('<ProjectsScreen/> delete refusal', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the selected project and shows the cleanup reason', async () => {
+    installAppBoundary({
+      listProjects: async () => [project],
+      deleteProject: async () => ({
+        ok: false,
+        reason: 'Knowledge cleanup did not finish.'
+      })
+    })
+    const user = userEvent.setup()
+    const { ProjectsScreen } = await import('../ProjectsScreen')
+
+    render(
+      <RendererEntitlementProvider>
+        <ProjectsScreen onOpenChat={() => undefined} />
+      </RendererEntitlementProvider>
+    )
+
+    expect((await screen.findAllByText(project.name)).length).toBeGreaterThan(0)
+    await user.click(screen.getByRole('button', { name: /knowledge & settings/i }))
+    await user.click(screen.getByTitle('Delete project'))
+
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Knowledge cleanup did not finish.'
+    )
+    await waitFor(() => expect(screen.getAllByText(project.name).length).toBeGreaterThan(0))
+  })
+})

--- a/src/renderer/src/components/ui/loading-dots.tsx
+++ b/src/renderer/src/components/ui/loading-dots.tsx
@@ -8,11 +8,12 @@ interface LoadingDotsProps {
 /** One three-dot busy state for every Desktop surface. */
 export function LoadingDots({ size = 'medium', className = '' }: LoadingDotsProps): ReactElement {
   const dot = size === 'small' ? 'h-1 w-1' : 'h-1.5 w-1.5'
+  const animation = 'animate-bounce motion-reduce:animate-none'
   return (
     <span className={`inline-flex items-center gap-1 px-1 ${className}`} aria-hidden="true">
-      <span className={`${dot} animate-bounce rounded-full bg-green-500 [animation-delay:0ms]`} />
-      <span className={`${dot} animate-bounce rounded-full bg-green-500 [animation-delay:150ms]`} />
-      <span className={`${dot} animate-bounce rounded-full bg-green-500 [animation-delay:300ms]`} />
+      <span className={`${dot} ${animation} rounded-full bg-green-500 [animation-delay:0ms]`} />
+      <span className={`${dot} ${animation} rounded-full bg-green-500 [animation-delay:150ms]`} />
+      <span className={`${dot} ${animation} rounded-full bg-green-500 [animation-delay:300ms]`} />
     </span>
   )
 }

--- a/src/renderer/src/lib/image-params.ts
+++ b/src/renderer/src/lib/image-params.ts
@@ -8,37 +8,34 @@
 // typed. The rule below makes the resolution explicit: a user override always
 // wins; only when there is no override do we fall back to the model default.
 
-import { standardModelDefaults } from '../../../shared/image-defaults'
+import {
+  effectiveImageParameter,
+  hasImageParameterOverride,
+  resolveImageParameters,
+  setImageParameterOverride,
+  type EffectiveImageParameters,
+  type ImageParameterOverride,
+  type ImageParameterStore
+} from '@offgrid/models'
 
 /** Per-model image params the user can override. Stored per model so switching
  *  models restores that model's last value, not a global one. `null`/`undefined`
  *  means "no override — use the model default". */
-export interface ImageParamOverride {
-  steps?: number | null
-  size?: number | null
-  cfgScale?: number | null
-}
+export type ImageParamOverride = ImageParameterOverride
 
 /** All persisted image-composer params, keyed by model filename. Shape mirrors
  *  what we round-trip through `saveSetting('imageParams', …)` / `getSettings()`. */
-export type ImageParamStore = Record<string, ImageParamOverride>
+export type ImageParamStore = ImageParameterStore
 
 /** The concrete params the composer should run with for a given model, after
  *  resolving overrides against the model's defaults. */
-export interface EffectiveImageParams {
-  steps: number
-  size: number
-  cfgScale: number
-}
+export type EffectiveImageParams = EffectiveImageParameters
 
 /** override ?? default. A user override (any finite number) wins; absent (null /
  *  undefined / NaN) falls back to the supplied default. Exported so both the
  *  steps and size resolvers, and their tests, share one rule. */
 export function effectiveValue(override: number | null | undefined, fallback: number): number {
-  if (typeof override === 'number' && Number.isFinite(override)) {
-    return override
-  }
-  return fallback
+  return effectiveImageParameter(override, fallback)
 }
 
 /** Resolve the effective steps + size for a model: the user's per-model override
@@ -49,20 +46,7 @@ export function resolveImageParams(
   model: string,
   store: ImageParamStore | null | undefined
 ): EffectiveImageParams {
-  const d = standardModelDefaults(model)
-  const o = store?.[model]
-  return {
-    steps: effectiveValue(o?.steps, d.defaultSteps),
-    size: effectiveValue(o?.size, d.defaultSize),
-    cfgScale: effectiveValue(o?.cfgScale, d.defaultCfg)
-  }
-}
-
-function defaultForKey(model: string, key: keyof ImageParamOverride): number {
-  const defaults = standardModelDefaults(model)
-  if (key === 'steps') return defaults.defaultSteps
-  if (key === 'size') return defaults.defaultSize
-  return defaults.defaultCfg
+  return resolveImageParameters({ id: model }, store)
 }
 
 /** Record a user override for one param of one model, returning a NEW store
@@ -74,20 +58,7 @@ export function setOverride(
   key: keyof ImageParamOverride,
   value: number
 ): ImageParamStore {
-  const next: ImageParamStore = { ...(store ?? {}) }
-  const modelDefault = defaultForKey(model, key)
-  const entry: ImageParamOverride = { ...(next[model] ?? {}) }
-  if (value === modelDefault) {
-    delete entry[key]
-  } else {
-    entry[key] = value
-  }
-  if (entry.steps == null && entry.size == null && entry.cfgScale == null) {
-    delete next[model]
-  } else {
-    next[model] = entry
-  }
-  return next
+  return setImageParameterOverride(store, model, key, value)
 }
 
 /** True when the user has an explicit override for this model+key (i.e. we must
@@ -97,6 +68,5 @@ export function hasOverride(
   model: string,
   key: keyof ImageParamOverride
 ): boolean {
-  const o = store?.[model]
-  return typeof o?.[key] === 'number' && Number.isFinite(o[key] as number)
+  return hasImageParameterOverride(store, model, key)
 }

--- a/src/shared/image-defaults.ts
+++ b/src/shared/image-defaults.ts
@@ -1,3 +1,9 @@
+import {
+  imageTaesdFilename,
+  standardImageModelDefaults,
+  type StandardImageModelDefaults
+} from '@offgrid/models'
+
 // Per-model image generation defaults — the SINGLE source of truth, shared by
 // BOTH the main process (sd-server + sd-cli runtimes in imagegen.ts) AND the
 // renderer (MemoryChat image composer). Keep it here in @offgrid/models so the
@@ -16,56 +22,11 @@
 // - Full (non-distilled) checkpoints need ~28 steps + real CFG for quality;
 //   dropping their step count wrecks the image, and they're fine on `discrete`.
 
-export interface StandardModelDefaults {
-  /** Default square size (px). Distilled fast-path is 512; full XL stays 1024. */
-  defaultSize: number
-  /** Denoising steps. Full checkpoints need many; distilled models are few-step. */
-  defaultSteps: number
-  /** Classifier-free guidance scale. */
-  defaultCfg: number
-  /** Sampling method. */
-  sampler: string
-  /** Denoiser sigma schedule. KARRAS is essential for crisp few-step output;
-   *  full models use the engine default (discrete). */
-  scheduler: string
-  /** Whether this is a distilled few-step model (Lightning/Turbo/DMD2). */
-  fewStep: boolean
-  /** Whether this is an SDXL-family model (larger native resolution). */
-  isXL: boolean
-}
+export type StandardModelDefaults = StandardImageModelDefaults
 
 /** Resolve the generation defaults for a checkpoint from its filename. */
 export function standardModelDefaults(baseName: string): StandardModelDefaults {
-  const base = baseName
-  const isLightning = /lightning/i.test(base)
-  const isTurbo = /turbo|dmd2?|hyper/i.test(base)
-  const isXL = /sdxl|xl/i.test(base) || isLightning
-  const isV2 = /v2-1|v2\.1/i.test(base)
-  const fewStep = isLightning || isTurbo
-  if (fewStep) {
-    // Approved config: 10 steps, cfg 2, dpm++2m, KARRAS, 512², FULL VAE (taesd
-    // blanks at high res; 512 full-VAE decodes in ~6s). ~30s warm on an M4.
-    return {
-      defaultSize: 512,
-      defaultSteps: 10,
-      defaultCfg: 2,
-      sampler: 'dpm++2m',
-      scheduler: 'karras',
-      fewStep,
-      isXL
-    }
-  }
-  // Full (non-distilled) checkpoints: many steps, real CFG, engine-default schedule.
-  const defaultSize = isXL ? 1024 : isV2 ? 768 : 512
-  return {
-    defaultSize,
-    defaultSteps: 28,
-    defaultCfg: 7,
-    sampler: 'dpm++2m',
-    scheduler: 'discrete',
-    fewStep,
-    isXL
-  }
+  return standardImageModelDefaults(baseName)
 }
 
 /** The Tiny AutoEncoder (TAESD) filename that matches a checkpoint's family.
@@ -74,5 +35,5 @@ export function standardModelDefaults(baseName: string): StandardModelDefaults {
  *  default. SDXL needs the SDXL-specific decoder (taesdxl); SD1.5/SD2 use the base
  *  taesd. The file is fetched separately (madebyollin/taesd*). Pure. */
 export function taesdFilename(baseName: string): string {
-  return standardModelDefaults(baseName).isXL ? 'taesdxl.safetensors' : 'taesd.safetensors'
+  return imageTaesdFilename(baseName)
 }

--- a/src/shared/llm-defaults.ts
+++ b/src/shared/llm-defaults.ts
@@ -21,13 +21,10 @@ export const MAX_TOKENS_AUTO = 0
 // Fresh-install / reset default for max output: auto (context is the limit, not a fixed number).
 export const DEFAULT_MAX_TOKENS = MAX_TOKENS_AUTO
 
-// Emergency ceiling for tool calls in one response. Keep this aligned with Off Grid AI Mobile so
-// a synced value has the same meaning on both products.
-export const MIN_MAX_TOOL_CALLS = 1
-export const MAX_MAX_TOOL_CALLS = 100
-export const DEFAULT_MAX_TOOL_CALLS = 25
-
-export function normalizeMaxToolCalls(value: number): number {
-  if (!Number.isFinite(value)) return DEFAULT_MAX_TOOL_CALLS
-  return Math.max(MIN_MAX_TOOL_CALLS, Math.min(MAX_MAX_TOOL_CALLS, Math.round(value)))
-}
+// Keep existing Desktop imports stable while Shared owns the cross-platform tool-call policy.
+export {
+  MIN_MAX_TOOL_CALLS,
+  MAX_MAX_TOOL_CALLS,
+  DEFAULT_MAX_TOOL_CALLS,
+  normalizeMaxToolCalls
+} from '@offgrid/models'

--- a/src/shared/project-delete-outcome.ts
+++ b/src/shared/project-delete-outcome.ts
@@ -1,0 +1,13 @@
+export type ProjectDeleteOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string }
+
+export const PROJECT_DELETE_FALLBACK_REASON = 'This project could not be deleted.'
+
+export function projectDeleteFailure(error: unknown): ProjectDeleteOutcome {
+  const reason = error instanceof Error ? error.message.trim() : String(error).trim()
+  return {
+    ok: false,
+    reason: reason || PROJECT_DELETE_FALLBACK_REASON
+  }
+}

--- a/src/shared/startup-contract.ts
+++ b/src/shared/startup-contract.ts
@@ -1,0 +1,18 @@
+export type StartupPhase = 'pending' | 'ready' | 'degraded' | 'failed'
+
+export type StartupStageStatus = 'running' | 'completed' | 'failed' | 'timeout' | 'late'
+
+export interface StartupStageSnapshot {
+  readonly name: string
+  readonly status: StartupStageStatus
+  readonly required: boolean
+  readonly durationMs?: number
+  readonly error?: string
+}
+
+export interface StartupSnapshot {
+  readonly revision: number
+  readonly phase: StartupPhase
+  readonly running: readonly string[]
+  readonly stages: readonly StartupStageSnapshot[]
+}


### PR DESCRIPTION
## Outcome

- Validate received model packages through the Shared transfer contract.
- Finish the LLM response after the tool-call limit.
- Keep image options, preparing previews, and final image width consistent.
- Record the accepted recovery follow-up backlog.

## Verification

- Model transfer was manually verified.
- Desktop tool-limit behavior was manually verified.
- Desktop image option and preview behavior was manually verified.
- Focused Desktop checks are recorded in recovery-progress.md.

## Known gate

The local pre-push typecheck still reports the pre-existing Shared RAG interface drift recorded in the F6 handoff.