### PR TITLE
fix(browser): bind manual tabs to their chat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           # Don't leave the cross-repo PAT in ./pro/.git/config where a later
           # PR-controlled step could reuse it — we only need it for the clone.
           persist-credentials: false
-      - name: Fall back to pro main if no matching branch
+      - name: Fall back to the Pro base branch if no matching branch
         if: ${{ steps.pro_branch.outcome != 'success' || hashFiles('pro/tsconfig.json') == '' }}
         continue-on-error: true
         uses: actions/checkout@v4
@@ -57,6 +57,7 @@ jobs:
           repository: off-grid-ai/desktop-pro
           token: ${{ secrets.CI_CROSS_REPO_TOKEN }}
           path: pro
+          ref: ${{ github.base_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: false
       # pro MUST be present: without it the guarded typecheck/coverage path is skipped and
@@ -90,7 +91,7 @@ jobs:
           path: _shared
           ref: ${{ github.head_ref || github.ref_name }}
           persist-credentials: false
-      - name: Fall back to shared main
+      - name: Fall back to the Shared base branch
         if: ${{ steps.shared_branch.outcome != 'success' }}
         continue-on-error: true
         uses: actions/checkout@v4
@@ -98,6 +99,7 @@ jobs:
           repository: off-grid-ai/shared
           token: ${{ secrets.CI_CROSS_REPO_TOKEN }}
           path: _shared
+          ref: ${{ github.base_ref || 'main' }}
           persist-credentials: false
       - name: Put shared beside this checkout
         run: |

--- a/src/main/browser/browser-host.ts
+++ b/src/main/browser/browser-host.ts
@@ -448,19 +448,24 @@ class BrowserHost implements BrowserRailHost {
     return child
   }
 
-  newTab(): { sessionId: string } {
+  newTab(journeyId?: string): { sessionId: string } {
     const sessionId = randomUUID()
-    const record = this.createSession({ sessionId, historyId: sessionId, kind: 'manual' })
+    const record = this.createSession({
+      sessionId,
+      historyId: sessionId,
+      kind: 'manual',
+      ...(journeyId ? { journeyId } : {})
+    })
     return { sessionId: record.sessionId }
   }
 
   /** Open a Chat link as a normal manual page. This is deliberately separate
    * from runTask: reading a source must never start Web Use automation. */
-  async openUrl(url: string): Promise<{ sessionId: string } | null> {
+  async openUrl(url: string, journeyId?: string): Promise<{ sessionId: string } | null> {
     if (!/^https?:\/\//i.test(url)) return null
     const target = normalizeBrowserAddress(url)
     if (!target) return null
-    const opened = this.newTab()
+    const opened = this.newTab(journeyId)
     await this.navigate(target, opened.sessionId)
     return opened
   }
@@ -1041,9 +1046,13 @@ export function registerBrowserViewIpc(): void {
     if (!isBrowserRegionOwner(owner)) return
     browserHost().setRegion(owner, parseRect(raw))
   })
-  ipcMain.handle('browser:new-tab', () => browserHost().newTab())
-  ipcMain.handle('browser:open-url', (_event, url: unknown) =>
-    typeof url === 'string' ? browserHost().openUrl(url) : null
+  ipcMain.handle('browser:new-tab', (_event, journeyId: unknown) =>
+    browserHost().newTab(typeof journeyId === 'string' ? journeyId : undefined)
+  )
+  ipcMain.handle('browser:open-url', (_event, url: unknown, journeyId: unknown) =>
+    typeof url === 'string'
+      ? browserHost().openUrl(url, typeof journeyId === 'string' ? journeyId : undefined)
+      : null
   )
   ipcMain.handle('browser:get-sessions', () => browserHost().getSessions())
   ipcMain.handle('browser:activate-session', (_event, sessionId: unknown) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -109,9 +109,10 @@ const offGridApi = {
       owner: 'docked' | 'floating',
       rect: { x: number; y: number; width: number; height: number } | null
     ) => ipcRenderer.send('browser:set-region', owner, rect),
-    newTab: (): Promise<{ sessionId: string }> => ipcRenderer.invoke('browser:new-tab'),
-    openUrl: (url: string): Promise<{ sessionId: string } | null> =>
-      ipcRenderer.invoke('browser:open-url', url),
+    newTab: (journeyId?: string): Promise<{ sessionId: string }> =>
+      ipcRenderer.invoke('browser:new-tab', journeyId),
+    openUrl: (url: string, journeyId?: string): Promise<{ sessionId: string } | null> =>
+      ipcRenderer.invoke('browser:open-url', url, journeyId),
     getSessions: (): Promise<BrowserSessionsSnapshot> => ipcRenderer.invoke('browser:get-sessions'),
     activateSession: (sessionId: string): Promise<boolean> =>
       ipcRenderer.invoke('browser:activate-session', sessionId),

--- a/src/renderer/src/components/ChatMarkdown.tsx
+++ b/src/renderer/src/components/ChatMarkdown.tsx
@@ -1,6 +1,7 @@
 import { preprocessChatMarkdown } from '@offgrid/sync'
 import { safeChatExternalUrl } from '@offgrid/sync'
 import { openChatLink } from '@renderer/lib/chat-link'
+import { useActiveConversationId } from '@renderer/lib/active-conversation'
 import { openTaskSidePanel } from '@renderer/lib/task-side-panel'
 import { useTaskSessions } from '@renderer/lib/task-session-store'
 import ReactMarkdown, { type Components } from 'react-markdown'
@@ -18,13 +19,14 @@ function ExternalChatLink({
   href?: string
   children?: React.ReactNode
 }): React.JSX.Element {
+  const conversationId = useActiveConversationId()
   return (
     <a
       href={safeChatExternalUrl(href) ?? undefined}
       className="text-green-500 underline"
       onClick={(event) => {
         event.preventDefault()
-        openChatLink(href)
+        openChatLink(href, conversationId)
       }}
     >
       {children}

--- a/src/renderer/src/components/MemoryChat.tsx
+++ b/src/renderer/src/components/MemoryChat.tsx
@@ -101,6 +101,7 @@ import { ActionGateDock } from '@renderer/components/actions/ActionGateDock'
 import { TaskPanelTrigger } from '@renderer/components/tasks/TaskPanelTrigger'
 import { useTaskWorkspaceOpen } from '@renderer/lib/task-side-panel'
 import { useWorkspacePaneController } from './workspace/useWorkspacePaneController'
+import { ActiveConversationProvider } from '@renderer/lib/ActiveConversationProvider'
 import {
   guidanceTaskForJourney,
   useTaskSessions,
@@ -4979,9 +4980,11 @@ export function MemoryChat({
     : null
 
   return (
-    <div
-      className="flex h-full flex-col font-mono bg-neutral-950 transition-[padding] duration-200"
-      style={{
+    <ActiveConversationProvider conversationId={activeConversationId}>
+      {/* prettier-ignore */}
+      <div
+        className="flex h-full flex-col font-mono bg-neutral-950 transition-[padding] duration-200"
+        style={{
         // Only the code/artifact canvas reflows content beside it (a deliberate
         // side-by-side edit surface). The drawers (settings, models, skills, gallery,
         // lightbox) are fixed overlays with their own opaque backdrop — they draw ON
@@ -4991,8 +4994,8 @@ export function MemoryChat({
             ? `${canvasWidth}px` // canvas open + resized → reflow content to its width
             : 'max(360px, 30vw)'
           : undefined
-      }}
-    >
+        }}
+      >
       {/* Header */}
       <header className="flex items-center gap-3 border-b border-neutral-900 px-6 py-4">
         <button
@@ -6831,6 +6834,7 @@ export function MemoryChat({
           </SidePanel>
         )}
       </AnimatePresence>
-    </div>
+      </div>
+    </ActiveConversationProvider>
   )
 }

--- a/src/renderer/src/components/chat-markdown-components.ts
+++ b/src/renderer/src/components/chat-markdown-components.ts
@@ -1,9 +1,29 @@
 import React from 'react'
 import { safeChatExternalUrl } from '@offgrid/sync'
 import { openChatLink } from '@renderer/lib/chat-link'
+import { useActiveConversationId } from '@renderer/lib/active-conversation'
 import type { Components } from 'react-markdown'
 
 const element = React.createElement
+
+function ChatMarkdownLink({
+  href,
+  children
+}: Readonly<{ href?: string; children?: React.ReactNode }>): React.JSX.Element {
+  const conversationId = useActiveConversationId()
+  return element(
+    'a',
+    {
+      href: safeChatExternalUrl(href) ?? undefined,
+      className: 'text-green-500 underline',
+      onClick: (event: React.MouseEvent) => {
+        event.preventDefault()
+        openChatLink(href, conversationId)
+      }
+    },
+    children
+  )
+}
 
 export const chatMarkdownComponents: Components = {
   h1: ({ children }) =>
@@ -63,19 +83,7 @@ export const chatMarkdownComponents: Components = {
       children
     ),
   hr: () => element('hr', { className: 'my-3 border-neutral-800' }),
-  a: ({ href, children }) =>
-    element(
-      'a',
-      {
-        href: safeChatExternalUrl(href) ?? undefined,
-        className: 'text-green-500 underline',
-        onClick: (event: React.MouseEvent) => {
-          event.preventDefault()
-          openChatLink(href)
-        }
-      },
-      children
-    ),
+  a: ChatMarkdownLink,
   code: ({ children, ...props }) =>
     element(
       'code',

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -183,8 +183,8 @@ interface RendererAPIOverrides {
       owner: 'docked' | 'floating',
       rect: { x: number; y: number; width: number; height: number } | null
     ) => void
-    newTab: () => Promise<{ sessionId: string }>
-    openUrl: (url: string) => Promise<{ sessionId: string } | null>
+    newTab: (journeyId?: string) => Promise<{ sessionId: string }>
+    openUrl: (url: string, journeyId?: string) => Promise<{ sessionId: string } | null>
     getSessions: () => Promise<{
       activeSessionId: string | null
       sessions: Array<{

--- a/src/renderer/src/lib/ActiveConversationProvider.tsx
+++ b/src/renderer/src/lib/ActiveConversationProvider.tsx
@@ -1,0 +1,13 @@
+import { type ReactNode } from 'react'
+import { ActiveConversationContext } from './active-conversation'
+
+export function ActiveConversationProvider({
+  conversationId,
+  children
+}: Readonly<{ conversationId: string | null; children: ReactNode }>): React.JSX.Element {
+  return (
+    <ActiveConversationContext.Provider value={conversationId}>
+      {children}
+    </ActiveConversationContext.Provider>
+  )
+}

--- a/src/renderer/src/lib/active-conversation.ts
+++ b/src/renderer/src/lib/active-conversation.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react'
+
+export const ActiveConversationContext = createContext<string | null>(null)
+
+export function useActiveConversationId(): string | null {
+  return useContext(ActiveConversationContext)
+}

--- a/src/renderer/src/lib/chat-link.ts
+++ b/src/renderer/src/lib/chat-link.ts
@@ -3,12 +3,16 @@ import { openExternal } from '../constants/links'
 import { openTaskSidePanel } from './task-side-panel'
 
 /** Open a link from Chat without turning a read into an automated Web Use task. */
-export function openChatLink(href: string | null | undefined): boolean {
+export function openChatLink(
+  href: string | null | undefined,
+  conversationId?: string | null
+): boolean {
   const safeUrl = safeChatExternalUrl(href)
   if (!safeUrl) return false
   if (/^https?:/i.test(safeUrl) && window.api.browser?.openUrl) {
     openTaskSidePanel({ kind: 'web_use' })
-    void window.api.browser.openUrl(safeUrl)
+    if (conversationId) void window.api.browser.openUrl(safeUrl, conversationId)
+    else void window.api.browser.openUrl(safeUrl)
     return true
   }
   openExternal(safeUrl)


### PR DESCRIPTION
## Outcome

- Bind browser tabs opened from Chat to the owning conversation.
- Prevent manual tabs from leaking into another Chat.
- Consume Desktop Pro's merged final-page docking and tab-retention recovery.

## Verification

- User manually verified final-page docking, new-tab retention, tab return, and Chat isolation.
- Production build passes.
- Hidden Web Use lifecycle E2E passes.
- 5,482 fast-suite tests pass.
- 360 real SQLite journey tests pass.
- New-code coverage gates pass, including 100% for the Desktop Pro projection logic.

Desktop Pro dependency: https://github.com/off-grid-ai/desktop-pro/pull/58