### PR TITLE
test(tools): allow dynamic result budget

### DIFF
--- a/src/main/__tests__/tools-loop.dbtest.ts
+++ b/src/main/__tests__/tools-loop.dbtest.ts
@@ -596,7 +596,10 @@ describe('agentic tool loop — real toolChat + real LLMService over a fake llam
       const result = await toolChat('read it', [], { connectors: true })
 
       expect(result.toolCalls[0]!.result.length).toBeLessThan(raw.length)
-      expect(result.toolCalls[0]!.result).toMatch(/result truncated: showing the first 1000/)
+      expect(result.toolCalls[0]!.result).toMatch(
+        /result truncated: showing the first \d+ of 30000 characters/
+      )
+      expect(result.toolCalls[0]!.result.length).toBeLessThanOrEqual(2_048 * 4)
       expect(JSON.stringify(fake.requests[1])).not.toContain(raw)
     } finally {
       service.ctxSize = previousContext


### PR DESCRIPTION
## Outcome
- keep the real tool-result window test aligned with the shared dynamic budget policy
- verify that large results are truncated and remain inside the active 2,048-token model window

## Evidence
- focused real-SQLite suite: 34/34 passed
- production behavior is unchanged

Follow-up to #110 after its hosted DB run exposed the fixed-value assertion.