### PR TITLE
fix(ci): make Desktop pre-push verification change-scoped

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,184 +1,45 @@
 #!/bin/sh
-# Pre-push coverage gate.
-#
-# Runs the test suite with coverage and enforces the thresholds in vitest.config.ts.
-# Those thresholds are a RATCHET FLOOR set just under current coverage: this blocks
-# regressions today without bricking pushes, and the floor rises toward the 85%
-# standard as tests are added (see CLAUDE.md "Coverage bar").
-#
-# Bypass in a genuine emergency with:  git push --no-verify
+# Fast local push gate. CI owns full coverage, DB, heavy integration, and E2E.
+set -e
 
-# Local gate mirrors CI's hard gates so a push can't be red on arrival: typecheck (fast
-# fail), then the coverage ratchet. Bypass only in a genuine emergency with --no-verify;
-# if a running app is holding a model port (:8439) so a port-owner test can't bind, stop it
-# first rather than bypassing — see CLAUDE.md "model ports are single-owner".
-echo "[pre-push] typecheck — npm run typecheck"
-if ! npm run --silent typecheck; then
-  echo ""
-  echo "[pre-push] BLOCKED: typecheck failed. Fix the type errors above before pushing."
-  exit 1
-fi
+ZERO_OID="0000000000000000000000000000000000000000"
 
-# Coverage is measured across EVERY suite and gated on the code this branch ADDS, not on whole files it
-# happened to touch. Three things were wrong with gating `npm run test:coverage` against vitest.config.ts's
-# thresholds:
-#
-#   1. That command runs ONE of three vitest projects, while the 85% floor beside it was calibrated on more -
-#      so a partial measurement was asked to clear a fuller floor, and had been failing on this branch
-#      regardless of what anyone did (82.4% branches vs 85%, verified both with and without recent changes).
-#   2. A file covered by the DB journeys or the e2e tour read as 0% here, because those suites report
-#      separately. src/main/database.ts and friends are excluded BY NAME for that reason - a hand-maintained
-#      list that silently rots.
-#   3. Whole-file denominators mean touching thirty lines of a two-thousand-line file drops 1970 untouched
-#      lines into the number, so no amount of testing the new lines can move it.
-#
-# So: run each suite, keep its report, gate once on the union. The floors are a RATCHET recording what this
-# branch achieves. Raise them as coverage rises; do not lower them to pass.
-echo "[pre-push] coverage 1/3 — unit + integration"
-# The app keeps SQLite built for Electron. The fast suite also contains real product
-# integrations that open SQLite under Node, so give them Node's ABI before Vitest starts.
-# The DB journey immediately below restores Electron's ABI in its EXIT trap.
-sqlite_needs_electron_restore=0
-restore_electron_sqlite() {
-  if [ "$sqlite_needs_electron_restore" != "1" ]; then
+collect_changed_files() {
+  if [ -t 0 ]; then
+    git diff --name-only --diff-filter=ACMR '@{upstream}..HEAD' 2>/dev/null || true
     return
   fi
-  sqlite_needs_electron_restore=0
-  echo "[pre-push] restoring SQLite for Electron"
-  npx electron-rebuild -f -w better-sqlite3-multiple-ciphers >/dev/null 2>&1 || \
-    npx electron-builder install-app-deps >/dev/null 2>&1 || true
-  ./scripts/probe-electron-sqlite.sh '[pre-push]'
-}
-trap restore_electron_sqlite EXIT
-if ! npm rebuild better-sqlite3-multiple-ciphers >/dev/null 2>&1; then
-  echo "[pre-push] BLOCKED: could not rebuild SQLite for the Node test runner."
-  exit 1
-fi
-sqlite_needs_electron_restore=1
-if ! npm run --silent test:coverage; then
-  echo ""
-  echo "[pre-push] NOTE: the fast suite reported failures or missed its own thresholds. The aggregate gate"
-  echo "[pre-push] below is the authority - but a failing TEST still blocks, because vitest writes no report"
-  echo "[pre-push] at all when one fails."
-fi
 
-echo "[pre-push] coverage 2/3 — DB journeys (real SQLite)"
-if ! OFFGRID_DB_VITEST_CONFIG=vitest.db.coverage.config.ts npm run --silent test:db -- --coverage; then
-  echo "[pre-push] NOTE: the DB journeys reported failures; their contribution may be missing below."
-fi
-# test-db.sh restores Electron's ABI in its own EXIT trap. The parent trap above
-# remains the interruption guard for every earlier exit path.
-sqlite_needs_electron_restore=0
+  while read -r _local_ref local_oid _remote_ref remote_oid; do
+    [ -z "$local_oid" ] && continue
+    [ "$local_oid" = "$ZERO_OID" ] && continue
 
-# Full Playwright e2e on the built app — the one gate the unit/integration suite can't give:
-# does the built app actually render + drive its surfaces. Specs needing real models/engine binaries
-# self-skip when absent, so this runs the model-free tour (onboarding, nav, Settings, Models,
-# Replay + capture toggle, Integrations).
-#
-# HEADLESS on macOS: `npm run test:e2e` sets OFFGRID_E2E_HEADLESS=1, so the app never calls show() and
-# stays out of the Dock (src/main/bootstrap/window-presentation.ts). Before that, every push opened ~25
-# maximized windows and took the keyboard away from whoever was working, so the gate was routinely
-# skipped with OFFGRID_SKIP_E2E=1 - quiet bought by not running the tests. Measured: 80 passed headless,
-# and the only specs that fail do so on a real display too. Watch a run with OFFGRID_E2E_HEADED=1.
-#
-# CONDITIONAL: the e2e boots its own app on a fresh profile and the smoke specs assert against the
-# fixed engine ports (:8439 llama, :7878 gateway). If ANOTHER Off Grid AI Desktop app is already running (the
-# installed app, or `npm run dev`), it holds those ports — the e2e app correctly falls back to a
-# free port (that's the whole feature), but the port-pinned smoke specs then hit the wrong instance
-# and false-fail. So skip the e2e gate when the ports are occupied and let CI (clean env) be the
-# authority; run it locally only when nothing else holds them. Bypass entirely with OFFGRID_SKIP_E2E=1.
-port_busy() { lsof -ti tcp:"$1" >/dev/null 2>&1; }
-# OFF BY DEFAULT. The e2e is a 6-minute suite and CI runs it on every PR anyway; running it on every
-# local push made the gate something to be worked around rather than trusted, and it is the single
-# biggest reason pushes here felt hostile. Ask for it explicitly when you want it:
-#   OFFGRID_E2E_ON_PUSH=1 git push        # this push runs the suite (on the box if it answers)
-if [ "${OFFGRID_E2E_ON_PUSH:-0}" != "1" ]; then
-  echo "[pre-push] e2e gate — not run (set OFFGRID_E2E_ON_PUSH=1 to run it here); CI runs it on the PR."
-elif [ "${OFFGRID_SKIP_E2E:-0}" = "1" ]; then
-  echo "[pre-push] e2e gate — skipped (OFFGRID_SKIP_E2E=1); CI still runs it."
-elif port_busy 8439 || port_busy 7878; then
-  echo "[pre-push] e2e gate — SKIPPED: an Off Grid AI Desktop app holds :8439/:7878, so a clean e2e can't run"
-  echo "[pre-push] here (the fresh-profile app would fall back off those ports and the port-pinned"
-  echo "[pre-push] smoke specs would false-fail). CI runs the full e2e in a clean environment."
-else
-  # ADVISORY, not blocking. NOTE: the old reason given here — "some specs need a real model/engine"
-  # — was a misdiagnosis. The specs that were failing had stale selectors, not missing models, and
-  # being advisory hid that for days. What remains is genuinely environment-dependent: the clipboard
-  # quick-open spec drives a real global hotkey (see docs/GAPS_BACKLOG.md) - it fails on a real display
-  # as well as headless, so window visibility is not what it is waiting for. Run it and SURFACE failures
-  # with screenshots without stopping the push; CI runs it too. Graduate to blocking once it is
-  # deterministic.
-  # OFFGRID_E2E_COVERAGE makes this tour COUNT towards the gate below. Without it, everything only the built
-  # app reaches - Electron bootstrap, IPC registration, rendered screens - reads as uncovered.
-  echo "[pre-push] coverage 3/3 + e2e (advisory)"
-  export OFFGRID_E2E_COVERAGE="$PWD/coverage-e2e-raw"
-  rm -rf "$OFFGRID_E2E_COVERAGE" coverage-e2e
-  # The TEST BOX first, whenever it answers. It is a clean machine with nothing else holding the engine
-  # ports, and it keeps ~25 app launches off the developer's screen entirely. Exit 20 means the box was
-  # unavailable rather than the suite failing, so that alone falls back to a local headless run - the
-  # gate must never silently skip because a machine was off.
-  e2e_status=0
-  if bash scripts/e2e-on-box.sh; then
-    e2e_status=0
-  else
-    e2e_status=$?
-    if [ "$e2e_status" -eq 20 ]; then
-      echo "[pre-push] the test box is unavailable — running the suite here (headless)"
-      npm run --silent test:e2e
-      e2e_status=$?
+    if [ "$remote_oid" = "$ZERO_OID" ]; then
+      # A new branch has no remote tip. Inspect only commits that are not already
+      # reachable from origin instead of assuming the branch started from main.
+      commits=$(git rev-list "$local_oid" --not --remotes=origin 2>/dev/null || true)
+      if [ -n "$commits" ]; then
+        git diff-tree --no-commit-id --name-only -r --diff-filter=ACMR $commits
+      fi
+    else
+      git diff --name-only --diff-filter=ACMR "$remote_oid..$local_oid"
     fi
-  fi
-  if [ "$e2e_status" -ne 0 ]; then
-    echo ""
-    echo "[pre-push] WARNING: e2e reported failures (see e2e/screenshots + output above). NOT blocking"
-    echo "[pre-push] the push. Do NOT assume it's environmental — check the actual failure. Re-run a"
-    echo "[pre-push] suspect spec with OFFGRID_E2E_HEADED=1 to watch it; if it fails there too, it is a"
-    echo "[pre-push] real break and not the headless run."
-  else
-    echo "[pre-push] e2e passed."
-  fi
-  # c8 turns the raw V8 output into an Istanbul report. Its statement map comes from the bundle, so the gate
-  # takes it as --coarse: covered lines only, never a denominator (it maps whole files, blank lines included).
-  if [ -n "$(ls -A "$OFFGRID_E2E_COVERAGE" 2>/dev/null)" ]; then
-    ../shared/node_modules/.bin/c8 report --temp-directory="$OFFGRID_E2E_COVERAGE" --reporter=json \
-      --report-dir=coverage-e2e --all=false >/dev/null 2>&1 || true
-  fi
+  done | sed '/^$/d' | sort -u
+}
+
+CHANGED_FILES=$(collect_changed_files)
+CHANGED_CODE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.(ts|tsx|js|jsx)$' || true)
+
+if [ -z "$CHANGED_CODE" ]; then
+  echo "[pre-push] no JavaScript or TypeScript changes — fast gate passed."
+  exit 0
 fi
 
-# The gate: the union of whatever reports the steps above produced.
-MEASURE=../shared/scripts/new-code-coverage.mjs
-REPORTS=""
-[ -f coverage/coverage-final.json ] && REPORTS="$REPORTS coverage/coverage-final.json"
-[ -f coverage-db/coverage-final.json ] && REPORTS="$REPORTS coverage-db/coverage-final.json"
-COARSE=""
-[ -f coverage-e2e/coverage-final.json ] && COARSE="--coarse=coverage-e2e/coverage-final.json"
+echo "[pre-push] typecheck"
+npm run --silent typecheck
 
-if [ -z "$REPORTS" ]; then
-  echo ""
-  echo "[pre-push] BLOCKED: no coverage report was produced, so nothing could be measured. One failing test"
-  echo "[pre-push] suppresses vitest's report entirely - fix the failure above."
-  exit 1
-fi
+echo "[pre-push] tests related to pushed files"
+printf '%s\n' "$CHANGED_CODE" | tr '\n' '\0' | \
+  xargs -0 npx vitest related --run --project product-integration --passWithNoTests --bail=1
 
-echo "[pre-push] coverage gate — new code, across every suite that ran"
-# Floors sit a little under what this branch achieves, because the e2e tour is advisory: it is skipped when the
-# model ports are busy, and its contribution disappears with it.
-if ! node "$MEASURE" . $REPORTS $COARSE --min-statements=78 --min-branches=57 --min-functions=52 --min-lines=78; then
-  echo ""
-  echo "[pre-push] BLOCKED: core's new code is below its floor. Add tests for the lines you added."
-  exit 1
-fi
-if [ -f pro/tsconfig.json ]; then
-  if ! node "$MEASURE" ./pro $REPORTS $COARSE --min-statements=72 --min-branches=45 --min-functions=46 --min-lines=72; then
-    echo ""
-    echo "[pre-push] BLOCKED: pro's new code is below its floor. Add tests for the lines you added."
-    exit 1
-  fi
-fi
-echo "[pre-push] coverage gate passed."
-
-# The gold-standard hygiene adoption has LANDED on this branch: prettier is applied repo-wide
-# (enforced by eslint's prettier/prettier rule) and the structural rules (curly / complexity /
-# max-lines / max-params / no-shadow …) are a warn ratchet in eslint.config.mjs. No standing
-# TODO here anymore — see CLAUDE.md "Code hygiene (adopted)". Tighten the ratchet to error as
-# the god-files decompose; never loosen it to pass.
+echo "[pre-push] fast gate passed. CI runs full coverage, DB, heavy integration, and E2E."


### PR DESCRIPTION
## Outcome

- Keep Desktop pushes fast by running typechecks and only related product tests.
- Leave full coverage, SQLite journeys, heavy integration, and E2E to CI.
- Detect the exact pushed commit range, including new branches based outside main.

## Verification

- Shell syntax passes.
- No-change push input exits successfully.
- Browser-related selection passed 241 tests in about 30 seconds.
- No production behavior changed.