### PR TITLE
CHAT-01: compact Desktop chats and show generation details

### DIFF
--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -98,12 +98,11 @@ function withContextMetrics(
   options: { contextWindowTokens?: number; tools?: unknown[] }
 ): StreamResult {
   const { contextWindowTokens, tools } = options
-  if (!contextWindowTokens || contextWindowTokens <= 0) return result
   return {
     ...result,
     metrics: {
       ...result.metrics,
-      contextWindowTokens,
+      ...(contextWindowTokens && contextWindowTokens > 0 ? { contextWindowTokens } : {}),
       ...(result.metrics?.promptTokens
         ? {}
         : { estimatedPromptTokens: Math.ceil(JSON.stringify({ messages, tools }).length / 4) })

--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -331,9 +331,10 @@ export class LLMService {
     }
   }
 
-  /** The EFFECTIVE (RAM-clamped) context window the server is actually running
-   *  with — the real ceiling for prompt + tools + answer. */
+  /** The selected app context cap. Local inference also needs the RAM clamp;
+   *  remote inference uses the configured cap without the local model's clamp. */
   effectiveContextSize(): number {
+    if (this.activeRemoteTextModel()) return this.ctxSize
     return this.safeCtxSize(this.ctxSize)
   }
 
@@ -1309,7 +1310,9 @@ export class LLMService {
         signal: opts.signal
       })
       return {
-        ...withContextMetrics(result, messages, { contextWindowTokens: remote.contextWindowTokens }),
+        ...withContextMetrics(result, messages, {
+          contextWindowTokens: this.effectiveContextSize()
+        }),
         maxTokens: resolvedMaxTokens
       }
     }
@@ -1384,7 +1387,7 @@ export class LLMService {
         toolChoice: opts.toolChoice
       })
       return withContextMetrics(result, messages, {
-        contextWindowTokens: remote.contextWindowTokens,
+        contextWindowTokens: this.effectiveContextSize(),
         tools: opts.tools
       })
     }

--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -92,6 +92,25 @@ export interface ChatStreamResult extends StreamResult {
   maxTokens: number
 }
 
+function withContextMetrics(
+  result: StreamResult,
+  messages: unknown[],
+  options: { contextWindowTokens?: number; tools?: unknown[] }
+): StreamResult {
+  const { contextWindowTokens, tools } = options
+  if (!contextWindowTokens || contextWindowTokens <= 0) return result
+  return {
+    ...result,
+    metrics: {
+      ...result.metrics,
+      contextWindowTokens,
+      ...(result.metrics?.promptTokens
+        ? {}
+        : { estimatedPromptTokens: Math.ceil(JSON.stringify({ messages, tools }).length / 4) })
+    }
+  }
+}
+
 export class LLMService {
   private readonly healthInvalidationListeners = new Set<() => void>()
   private server: ChildProcess | null = null
@@ -1290,7 +1309,10 @@ export class LLMService {
         thinking: opts.thinking,
         signal: opts.signal
       })
-      return { ...result, maxTokens: resolvedMaxTokens }
+      return {
+        ...withContextMetrics(result, messages, { contextWindowTokens: remote.contextWindowTokens }),
+        maxTokens: resolvedMaxTokens
+      }
     }
     await this.beginGeneration()
     try {
@@ -1319,7 +1341,10 @@ export class LLMService {
         signal: opts.signal,
         timeoutMs
       })
-      return { ...result, maxTokens: resolvedMaxTokens }
+      return {
+        ...withContextMetrics(result, messages, { contextWindowTokens: this.effectiveContextSize() }),
+        maxTokens: resolvedMaxTokens
+      }
     } finally {
       this.finishGeneration()
     }
@@ -1348,7 +1373,7 @@ export class LLMService {
   ): Promise<StreamResult> {
     const remote = this.activeRemoteTextModel()
     if (remote) {
-      return this.completeRemote(remote, messages, onDelta, {
+      const result = await this.completeRemote(remote, messages, onDelta, {
         timeoutMs,
         maxTokens: opts.maxTokens,
         temperature: opts.temperature,
@@ -1358,6 +1383,10 @@ export class LLMService {
         responseFormat: opts.responseFormat,
         tools: opts.tools,
         toolChoice: opts.toolChoice
+      })
+      return withContextMetrics(result, messages, {
+        contextWindowTokens: remote.contextWindowTokens,
+        tools: opts.tools
       })
     }
     await this.beginGeneration()
@@ -1385,9 +1414,13 @@ export class LLMService {
 
       // Single SSE transport (llm/stream.ts) — same path as chatStream, but the
       // assembled tool calls are surfaced too (this powers the agentic loop).
-      return await streamCompletion(this.port, body, onDelta, {
+      const result = await streamCompletion(this.port, body, onDelta, {
         signal: opts.signal,
         timeoutMs
+      })
+      return withContextMetrics(result, messages, {
+        contextWindowTokens: this.effectiveContextSize(),
+        tools: opts.tools
       })
     } finally {
       this.finishGeneration()

--- a/src/main/llm/remote-chat.ts
+++ b/src/main/llm/remote-chat.ts
@@ -13,6 +13,7 @@ export interface RemoteTextModelConnection {
   endpoint: string
   model: string
   apiKey: string
+  contextWindowTokens?: number
 }
 
 export interface RemoteChatRequest {

--- a/src/main/tools.ts
+++ b/src/main/tools.ts
@@ -7,6 +7,7 @@
 // search + MCP connectors plug in here later.
 
 import { llm } from './llm'
+import type { GenerationMetrics } from '../shared/generation-metrics'
 import { SEARCH_KB_TOOL, makeSearchKnowledgeBaseHandler } from '@offgrid/rag'
 import { stripChatControlTokens } from '@offgrid/sync'
 import { isMemoryToolAllowed } from './tools/memory-scope'
@@ -692,10 +693,12 @@ export async function toolChat(
     answer: string
     toolCalls: ToolCall[]
     unified: UnifiedSource[]
+    metrics?: GenerationMetrics
   }): {
     answer: string
     toolCalls: ToolCall[]
     unified: UnifiedSource[]
+    metrics?: GenerationMetrics
     imageRequests: (ProposalDeferredImageRequest | { prompt: string })[]
     imageRequest?: { prompt: string }
   } => {
@@ -720,7 +723,7 @@ export async function toolChat(
     // Stream this round: reasoning + any answer text flow through onDelta live; tool_calls
     // are accumulated and returned. A tool-calling round streams thinking (and no content);
     // the final round streams the answer. tool temperature stays 0.3 (was the blocking path).
-    const { content, toolCalls: calls } = await llm.streamChat(messages, onDelta, {
+    const { content, toolCalls: calls, metrics } = await llm.streamChat(messages, onDelta, {
       tools,
       toolChoice: 'auto',
       temperature: 0.3,
@@ -736,7 +739,7 @@ export async function toolChat(
     // them — a cancelled turn fires no side effects (e.g. an MCP send/create).
     // Return what we have; the renderer treats the turn as cancelled.
     if (opts.signal?.aborted)
-      return resultWithImages({ answer: content.trim(), toolCalls, unified })
+      return resultWithImages({ answer: content.trim(), toolCalls, unified, metrics })
 
     // Native tool_calls are preferred; but small on-device models (the gemma-4 we
     // ship) often emit a call as TEXT instead of on the tool_calls channel. When
@@ -811,14 +814,14 @@ export async function toolChat(
         messages.push({ role: 'tool', tool_call_id: c.id, content: res.text })
         if (res.authoritative) {
           onDelta(res.text, 'content')
-          return resultWithImages({ answer: res.text, toolCalls, unified })
+          return resultWithImages({ answer: res.text, toolCalls, unified, metrics })
         }
       }
       round += 1
       continue // let the model use the results
     }
     // No tool calls this round: `content` is the final answer (already streamed via onDelta).
-    return resultWithImages({ answer: answerFrom(content), toolCalls, unified })
+    return resultWithImages({ answer: answerFrom(content), toolCalls, unified, metrics })
   }
   // The configured emergency cap was reached with the model still calling tools. Instead of dead-ending
   // with a canned "stopped" message, FORCE one final answer WITHOUT tools, so the
@@ -840,7 +843,8 @@ export async function toolChat(
   return resultWithImages({
     answer: answerFrom(final.content) || 'Stopped after too many tool steps.',
     toolCalls,
-    unified
+    unified,
+    metrics: final.metrics
   })
 }
 

--- a/src/main/vision/remote-vision-server.ts
+++ b/src/main/vision/remote-vision-server.ts
@@ -24,6 +24,7 @@ interface StoredRemoteVisionServer {
   endpoint: string
   model: string
   screenFramesAllowed: boolean
+  contextWindowTokens?: number
 }
 
 interface StoredRemoteVisionConfig {
@@ -71,7 +72,10 @@ function normalizeServer(
     provider: value.provider,
     endpoint: remoteVisionApiBase(remoteVisionEndpoint(value.provider, value.endpoint)),
     model: value.model.trim(),
-    screenFramesAllowed: value.screenFramesAllowed === true
+    screenFramesAllowed: value.screenFramesAllowed === true,
+    ...(Number.isSafeInteger(value.contextWindowTokens) && (value.contextWindowTokens ?? 0) > 0
+      ? { contextWindowTokens: value.contextWindowTokens }
+      : {})
   }
 }
 
@@ -198,7 +202,10 @@ export function setRemoteVisionServerSettings(
     provider: update.provider,
     endpoint,
     model,
-    screenFramesAllowed: update.screenFramesAllowed === true
+    screenFramesAllowed: update.screenFramesAllowed === true,
+    ...(Number.isSafeInteger(update.contextWindowTokens) && (update.contextWindowTokens ?? 0) > 0
+      ? { contextWindowTokens: update.contextWindowTokens }
+      : {})
   }
   const servers = stored.servers.some((server) => server.id === id)
     ? stored.servers.map((server) => (server.id === id ? next : server))

--- a/src/renderer/src/components/MemoryChat.tsx
+++ b/src/renderer/src/components/MemoryChat.tsx
@@ -1191,13 +1191,24 @@ function GenerationMetricsRow({
   metrics
 }: Readonly<{ metrics?: GenerationMetrics }>): React.JSX.Element | null {
   const parts = metrics ? formatGenerationMetrics(metrics) : []
-  if (!parts.length) return null
+  const contextWindowTokens = metrics?.contextWindowTokens
+  const promptTokens = metrics?.promptTokens ?? metrics?.estimatedPromptTokens
+  const contextPercent =
+    promptTokens && contextWindowTokens && contextWindowTokens > 0
+      ? Math.round((promptTokens / contextWindowTokens) * 100)
+      : null
+  if (!parts.length && contextPercent === null) return null
   return (
     <p
       className="mt-2 font-mono text-[10px] tabular-nums text-neutral-500"
       data-testid="generation-metrics"
     >
-      {parts.join(' · ')}
+      {[
+        ...(contextPercent === null
+          ? []
+          : [`Context: ${metrics?.promptTokens ? '' : '~'}${contextPercent}% used`]),
+        ...parts
+      ].join(' · ')}
     </p>
   )
 }
@@ -2020,7 +2031,9 @@ function MessageBubble({
         <MessageMarkdown message={message} navigation={navigation} />
       )}
       <ResponseCutoffNotice cutoff={message.cutoff} />
-      {state.showGenerationDetails ? <GenerationMetricsRow metrics={message.metrics} /> : null}
+      {state.showGenerationDetails ? (
+        <GenerationMetricsRow metrics={message.metrics} />
+      ) : null}
       <ImageMemoryRetryAction
         message={message}
         loading={state.loading}
@@ -3927,11 +3940,22 @@ export function MemoryChat({
         setConvMessages(convId, (prev) =>
           prev.map((m) =>
             m.id === toolStreamId
-              ? { ...m, content: answer, context, toolCalls, activity: undefined, streaming: false }
+              ? {
+                  ...m,
+                  content: answer,
+                  context,
+                  toolCalls,
+                  metrics: tr?.metrics,
+                  activity: undefined,
+                  streaming: false
+                }
               : m
           )
         )
-        const toolCtxWithReasoning = buildAssistantContext(toolCtx, { reasoning: toolReasoning })
+        const toolCtxWithReasoning = buildAssistantContext(toolCtx, {
+          reasoning: toolReasoning,
+          metrics: tr?.metrics
+        })
         // Deferred image generation: the tool loop only RECORDS prompts (it never generates inline,
         // which would evict the LLM). Each completed request gets one generated file and one durable
         // assistant image message. A message context has one imageRef by design; putting two results

--- a/src/renderer/src/components/MemoryChat.tsx
+++ b/src/renderer/src/components/MemoryChat.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { shouldQueue, enqueue, dequeue, queuedCount, clearQueue } from '@renderer/lib/chat-queue'
-import { buildSendHistory } from '@renderer/lib/chat-history'
+import { buildSendHistory, EARLIER_CHAT_EXCERPTS_PREFIX } from '@renderer/lib/chat-history'
 import { waitingLabel } from '@renderer/lib/chat-labels'
 import { parseSqliteUtc, shiftLocalDay, startOfLocalDay, timeAgo } from '@renderer/lib/time'
 import { writeClipboardWithFallback } from '@renderer/lib/clipboard-write'
@@ -152,6 +152,7 @@ type RagEntity = { id: number; name?: string }
 type RagEntityFact = { fact?: string } | string
 
 type RagContext = {
+  notice?: boolean
   masterMemory?: string | null
   memories?: RagMemory[]
   messages?: unknown[]
@@ -549,6 +550,10 @@ function projectChatMessage(turn: ProjectedTurn, context?: RagContext): ChatMess
 function mapRagMessage(message: RawRagMessage): ChatMessage[] {
   const context = parseRagContext(message.context)
   const provenance = readRagProvenance(message)
+  if (context?.notice && noticeText(message.content) === 'Compacted') {
+    const id = String(message.uuid ?? message.id ?? '')
+    return id ? [{ id, role: 'assistant', content: message.content, notice: true }] : []
+  }
   // Shared excludes this temporary row from the portable answer projection. Desktop still needs
   // the local row until the same UUID becomes the durable Enhanced prompt disclosure.
   const promptEnhancement = promptEnhancementMessage(message, provenance)
@@ -707,10 +712,20 @@ function contextResultCount(context: RagContext): number {
 }
 
 function NoticeMessageRow({ message }: Readonly<{ message: ChatMessage }>): React.JSX.Element {
+  const text = noticeText(message.content)
+  if (text === 'Compacted') {
+    return (
+      <div className="mb-2 flex items-start" aria-live="polite">
+        <span className="rounded-sm border border-neutral-800 px-2.5 py-2 text-[11px] text-neutral-500">
+          {text}
+        </span>
+      </div>
+    )
+  }
   return (
     <div className="mb-4 flex justify-center">
       <span className="px-3 text-center text-[11px] leading-relaxed text-neutral-500">
-        {noticeText(message.content)}
+        {text}
       </span>
     </div>
   )
@@ -3819,7 +3834,31 @@ export function MemoryChat({
       // History is built from the TARGET conversation's own messages (never the
       // active tab's `messages`) — a drained-queue or background send is bound to
       // `convId`, so its history must come from that conversation (D8).
-      const history = buildSendHistory(messagesByConv[convId] ?? EMPTY_MSGS, !!regen, trimmed)
+      const historyLimit = (messagesByConv[convId]?.length ?? 0) >= 20 ? 8 : 20
+      const history = buildSendHistory(
+        messagesByConv[convId] ?? EMPTY_MSGS,
+        !!regen,
+        trimmed,
+        historyLimit
+      )
+      if (
+        history[0]?.content.startsWith(EARLIER_CHAT_EXCERPTS_PREFIX) &&
+        !(messagesByConv[convId] ?? EMPTY_MSGS).some(
+          (message) => message.notice && noticeText(message.content) === 'Compacted'
+        )
+      ) {
+        try {
+          const stored = await window.api.addRagMessage(convId, 'assistant', '_Compacted_', {
+            notice: true
+          })
+          setConvMessages(convId, (previous) => [
+            ...previous,
+            { id: stored.uuid, role: 'assistant', content: '_Compacted_', notice: true }
+          ])
+        } catch (error) {
+          console.warn('Could not save the compaction notice', error)
+        }
+      }
 
       // Agentic tools path (opt-in, non-project). The model calls built-in tools,
       // plus (when Connectors is on) MCP connector tools. STREAMS like the RAG path:

--- a/src/renderer/src/components/MemoryChat.tsx
+++ b/src/renderer/src/components/MemoryChat.tsx
@@ -1197,16 +1197,20 @@ function GenerationMetricsRow({
     promptTokens && contextWindowTokens && contextWindowTokens > 0
       ? Math.round((promptTokens / contextWindowTokens) * 100)
       : null
-  if (!parts.length && contextPercent === null) return null
+  const contextLabel =
+    contextPercent !== null
+      ? `Context: ${metrics?.promptTokens ? '' : '~'}${contextPercent}% used`
+      : promptTokens
+        ? `Context: ${metrics?.promptTokens ? '' : '~'}${promptTokens} tokens used (limit unknown)`
+        : null
+  if (!parts.length && contextLabel === null) return null
   return (
     <p
       className="mt-2 font-mono text-[10px] tabular-nums text-neutral-500"
       data-testid="generation-metrics"
     >
       {[
-        ...(contextPercent === null
-          ? []
-          : [`Context: ${metrics?.promptTokens ? '' : '~'}${contextPercent}% used`]),
+        ...(contextLabel === null ? [] : [contextLabel]),
         ...parts
       ].join(' · ')}
     </p>

--- a/src/renderer/src/components/MemoryChat.tsx
+++ b/src/renderer/src/components/MemoryChat.tsx
@@ -3851,12 +3851,16 @@ export function MemoryChat({
       // History is built from the TARGET conversation's own messages (never the
       // active tab's `messages`) — a drained-queue or background send is bound to
       // `convId`, so its history must come from that conversation (D8).
-      const historyLimit = (messagesByConv[convId]?.length ?? 0) >= 20 ? 8 : 20
+      const contextWindowTokens = await window.api
+        .getLlmSettings()
+        .then((settings) => settings?.ctxSize)
+        .catch(() => undefined)
       const history = buildSendHistory(
         messagesByConv[convId] ?? EMPTY_MSGS,
         !!regen,
         trimmed,
-        historyLimit
+        20,
+        contextWindowTokens
       )
       if (
         history[0]?.content.startsWith(EARLIER_CHAT_EXCERPTS_PREFIX) &&

--- a/src/renderer/src/components/RemoteVisionSettingsTab.tsx
+++ b/src/renderer/src/components/RemoteVisionSettingsTab.tsx
@@ -26,6 +26,7 @@ interface ServerForm {
   model: string
   hasApiKey: boolean
   screenFramesAllowed: boolean
+  contextWindowTokens: string
 }
 
 const EMPTY_FORM: ServerForm = {
@@ -34,7 +35,8 @@ const EMPTY_FORM: ServerForm = {
   endpoint: '',
   model: '',
   hasApiKey: false,
-  screenFramesAllowed: false
+  screenFramesAllowed: false,
+  contextWindowTokens: ''
 }
 
 interface RemoteModelOption {
@@ -49,7 +51,8 @@ function formFromServer(server: RemoteVisionSavedServer): ServerForm {
     endpoint: server.endpoint,
     model: server.model,
     hasApiKey: server.hasApiKey,
-    screenFramesAllowed: server.screenFramesAllowed
+    screenFramesAllowed: server.screenFramesAllowed,
+    contextWindowTokens: server.contextWindowTokens ? String(server.contextWindowTokens) : ''
   }
 }
 
@@ -154,7 +157,8 @@ export function RemoteVisionSettingsTab(): React.JSX.Element {
       serverId: form.id ?? undefined,
       name: form.name,
       ...(apiKey ? { apiKey } : {}),
-      screenFramesAllowed: form.screenFramesAllowed
+      screenFramesAllowed: form.screenFramesAllowed,
+      ...(form.contextWindowTokens ? { contextWindowTokens: Number(form.contextWindowTokens) } : {})
     }
   }
 
@@ -228,6 +232,14 @@ export function RemoteVisionSettingsTab(): React.JSX.Element {
     }
     if (remoteEnabled && !form.model) {
       setStatus('Test the connection and select a model first.')
+      return
+    }
+    if (
+      form.contextWindowTokens &&
+      (!Number.isSafeInteger(Number(form.contextWindowTokens)) ||
+        Number(form.contextWindowTokens) < 1024)
+    ) {
+      setStatus('Enter a context window of at least 1024 tokens.')
       return
     }
     setBusy(true)
@@ -390,6 +402,7 @@ export function RemoteVisionSettingsTab(): React.JSX.Element {
                     ...current,
                     endpoint: event.target.value,
                     model: '',
+                    contextWindowTokens: '',
                     screenFramesAllowed: false
                   }))
                   setModels([])
@@ -469,7 +482,7 @@ export function RemoteVisionSettingsTab(): React.JSX.Element {
                     onFocus={() => setShowModels(true)}
                     onChange={(event) => {
                       setModelQuery(event.target.value)
-                      setForm((current) => ({ ...current, model: '' }))
+                      setForm((current) => ({ ...current, model: '', contextWindowTokens: '' }))
                       setShowModels(true)
                     }}
                     placeholder="Search models"
@@ -484,7 +497,12 @@ export function RemoteVisionSettingsTab(): React.JSX.Element {
                             key={model.id}
                             type="button"
                             onClick={() => {
-                              setForm((current) => ({ ...current, model: model.id }))
+                              setForm((current) => ({
+                                ...current,
+                                model: model.id,
+                                contextWindowTokens:
+                                  current.model === model.id ? current.contextWindowTokens : ''
+                              }))
                               setModelQuery(model.name)
                               setShowModels(false)
                               setStatus('Not saved.')
@@ -509,6 +527,25 @@ export function RemoteVisionSettingsTab(): React.JSX.Element {
                 </div>
               </Row>
             ) : null}
+            <Row
+              label="Context window"
+              controlId="remote-context-window"
+              hint="Tokens for this remote model. Leave empty if unknown."
+            >
+              <input
+                id="remote-context-window"
+                type="number"
+                min={1024}
+                step={1024}
+                value={form.contextWindowTokens}
+                onChange={(event) => {
+                  setForm((current) => ({ ...current, contextWindowTokens: event.target.value }))
+                  setStatus('Not saved.')
+                }}
+                placeholder="e.g., 131072"
+                className="w-full rounded-md border border-neutral-800 bg-neutral-900 px-2.5 py-1.5 text-xs text-neutral-200 outline-none placeholder:text-neutral-600 focus-visible:border-green-500"
+              />
+            </Row>
           </>
         ) : null}
       </div>

--- a/src/renderer/src/components/RemoteVisionSettingsTab.tsx
+++ b/src/renderer/src/components/RemoteVisionSettingsTab.tsx
@@ -234,14 +234,6 @@ export function RemoteVisionSettingsTab(): React.JSX.Element {
       setStatus('Test the connection and select a model first.')
       return
     }
-    if (
-      form.contextWindowTokens &&
-      (!Number.isSafeInteger(Number(form.contextWindowTokens)) ||
-        Number(form.contextWindowTokens) < 1024)
-    ) {
-      setStatus('Enter a context window of at least 1024 tokens.')
-      return
-    }
     setBusy(true)
     setStatus('Saving...')
     try {
@@ -527,25 +519,6 @@ export function RemoteVisionSettingsTab(): React.JSX.Element {
                 </div>
               </Row>
             ) : null}
-            <Row
-              label="Context window"
-              controlId="remote-context-window"
-              hint="Tokens for this remote model. Leave empty if unknown."
-            >
-              <input
-                id="remote-context-window"
-                type="number"
-                min={1024}
-                step={1024}
-                value={form.contextWindowTokens}
-                onChange={(event) => {
-                  setForm((current) => ({ ...current, contextWindowTokens: event.target.value }))
-                  setStatus('Not saved.')
-                }}
-                placeholder="e.g., 131072"
-                className="w-full rounded-md border border-neutral-800 bg-neutral-900 px-2.5 py-1.5 text-xs text-neutral-200 outline-none placeholder:text-neutral-600 focus-visible:border-green-500"
-              />
-            </Row>
           </>
         ) : null}
       </div>

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -386,7 +386,7 @@ export function SettingsPanel({
               label="Generation details"
               controlId="generation-details-toggle"
               value={showGenerationDetails ? 'Shown' : 'Hidden'}
-              hint="Print the speed, token count, and time to first token under each answer."
+              hint="Show context use, speed, token count, and time under each answer."
             >
               <button
                 id="generation-details-toggle"

--- a/src/renderer/src/lib/chat-history.ts
+++ b/src/renderer/src/lib/chat-history.ts
@@ -27,7 +27,8 @@ export function buildSendHistory<T extends HistoryTurn>(
   convMsgs: readonly T[],
   regen: boolean,
   newUserText: string,
-  limit = 20
+  limit = 20,
+  contextWindowTokens?: number
 ): HistoryTurn[] {
   // Task guidance is shown in Chat for continuity, but the operator already
   // consumed it. Do not replay it as another user prompt to the resident LLM.
@@ -42,10 +43,16 @@ export function buildSendHistory<T extends HistoryTurn>(
     base = [...flat, { role: 'user', content: newUserText }]
   }
   if (base.length === 0) return []
-  if (limit <= 1) return base.slice(-1)
+  const estimatedTokens = Math.ceil(JSON.stringify(base).length / 4)
+  if (contextWindowTokens && estimatedTokens < contextWindowTokens * 0.8) return base
+  const effectiveLimit =
+    contextWindowTokens && estimatedTokens >= contextWindowTokens * 0.8 && base.length > 2
+      ? Math.min(limit, Math.max(2, Math.floor(base.length / 2)))
+      : limit
+  if (effectiveLimit <= 1) return base.slice(-1)
   // The active turn is never shortened. Prior turns share a fixed budget so a
   // few very large messages cannot exhaust the model context by themselves.
-  const recent = base.length <= limit ? base : base.slice(-(limit - 1))
+  const recent = base.length <= effectiveLimit ? base : base.slice(-(effectiveLimit - 1))
   const older = base.slice(0, base.length - recent.length)
   const excerptTurns = older.length
     ? [older[0]!, ...older.slice(-3).filter((turn) => turn !== older[0])]

--- a/src/renderer/src/lib/chat-history.ts
+++ b/src/renderer/src/lib/chat-history.ts
@@ -13,9 +13,12 @@ export interface HistoryTurn {
   role: string
   content: string
   context?: { taskGuidance?: unknown } | null
+  notice?: boolean
 }
 
-/** Build the last `limit` turns of history for a send.
+export const EARLIER_CHAT_EXCERPTS_PREFIX = 'Earlier chat excerpts'
+
+/** Build bounded history for a send.
  *  - regen: the latest user turn is already in the thread → keep up to and
  *    including it (drop anything after).
  *  - normal send: append the new user turn.
@@ -29,7 +32,7 @@ export function buildSendHistory<T extends HistoryTurn>(
   // Task guidance is shown in Chat for continuity, but the operator already
   // consumed it. Do not replay it as another user prompt to the resident LLM.
   const flat = convMsgs
-    .filter((message) => !message.context?.taskGuidance)
+    .filter((message) => !message.context?.taskGuidance && !message.notice)
     .map((m) => ({ role: m.role, content: m.content }))
   let base: HistoryTurn[]
   if (regen) {
@@ -38,5 +41,38 @@ export function buildSendHistory<T extends HistoryTurn>(
   } else {
     base = [...flat, { role: 'user', content: newUserText }]
   }
-  return base.slice(-limit)
+  if (base.length === 0) return []
+  if (limit <= 1) return base.slice(-1)
+  // The active turn is never shortened. Prior turns share a fixed budget so a
+  // few very large messages cannot exhaust the model context by themselves.
+  const recent = base.length <= limit ? base : base.slice(-(limit - 1))
+  const older = base.slice(0, base.length - recent.length)
+  const excerptTurns = older.length
+    ? [older[0]!, ...older.slice(-3).filter((turn) => turn !== older[0])]
+    : []
+  const excerpts = excerptTurns.map(
+    (turn) => `${turn.role === 'assistant' ? 'Assistant' : 'User'}: ${turn.content.slice(0, 90)}`
+  )
+  const prior: HistoryTurn[] = [
+    ...(older.length
+      ? [
+          {
+            role: 'user',
+            content: `${EARLIER_CHAT_EXCERPTS_PREFIX} (${older.length} turns; some details omitted): ${excerpts.join(' | ')}`
+          }
+        ]
+      : []),
+    ...recent.slice(0, -1)
+  ]
+  const charsPerTurn = Math.max(1, Math.floor(3000 / Math.max(1, prior.length)))
+  return [
+    ...prior.map((turn) => ({
+      ...turn,
+      content:
+        turn.content.length > charsPerTurn
+          ? `${turn.content.slice(0, charsPerTurn - 1)}…`
+          : turn.content
+    })),
+    recent[recent.length - 1]!
+  ]
 }

--- a/src/renderer/src/lib/message-persistence.ts
+++ b/src/renderer/src/lib/message-persistence.ts
@@ -98,7 +98,9 @@ export function readGenerationMetrics(ctx: unknown): GenerationMetrics | undefin
     'decodeTokensPerSecond',
     'prefillTokensPerSecond',
     'promptTokens',
-    'completionTokens'
+    'completionTokens',
+    'contextWindowTokens',
+    'estimatedPromptTokens'
   ] as const
   const metrics: Record<string, number> = {}
   for (const key of keys) {

--- a/src/shared/generation-metrics.ts
+++ b/src/shared/generation-metrics.ts
@@ -37,6 +37,10 @@ export interface GenerationMetrics {
   prefillTokensPerSecond?: number
   promptTokens?: number
   completionTokens?: number
+  /** Context window used for this reply, captured before model selection can change. */
+  contextWindowTokens?: number
+  /** Prompt size estimate when the server does not report prompt tokens. */
+  estimatedPromptTokens?: number
 }
 
 function positive(value: number | undefined): number | undefined {

--- a/src/shared/remote-vision-server.ts
+++ b/src/shared/remote-vision-server.ts
@@ -18,6 +18,8 @@ export interface RemoteVisionSavedServer {
   hasApiKey: boolean
   /** The user has confirmed that this remote server can receive screen images. */
   screenFramesAllowed: boolean
+  /** User-configured context window for this selected remote model. */
+  contextWindowTokens?: number
 }
 
 export interface RemoteVisionModelReference {
@@ -93,6 +95,7 @@ export interface RemoteVisionServerUpdate {
   apiKey?: string
   clearApiKey?: boolean
   screenFramesAllowed?: boolean
+  contextWindowTokens?: number
 }
 
 export interface RemoteVisionConnectionResult {


### PR DESCRIPTION
## Summary
- Keep the active turn intact while older Desktop chat history is bounded and marked as compacted.
- Keep tool-chat generation metrics with each reply, including after reload.
- Show context use under replies. Save a context window for each selected remote model when the server does not report one.

## Checks
- Desktop typecheck passed.
- Live chat verification is still open. One earlier UI test attempt failed before chat opened. No further E2E tests were run, as requested.
- Unrelated working-tree files are not in this PR.