### PR TITLE
fix: show real memory-chat generation failures

### DIFF
--- a/integration-tests/workspace-production-bridge.ui.integration.dbtest.tsx
+++ b/integration-tests/workspace-production-bridge.ui.integration.dbtest.tsx
@@ -129,16 +129,11 @@ let TooltipProvider: typeof import('../src/renderer/src/components/ui/tooltip').
 async function bootProductionMain(): Promise<void> {
   bridge.handlers.clear()
   bridge.mainListeners.clear()
-  const [{ setupIPC }, { setupRagIPC }, { llm }, { registerTaskHistoryIpc }] = await Promise.all([
+  const [{ setupIPC }, { setupRagIPC }, { registerTaskHistoryIpc }] = await Promise.all([
     import('../src/main/ipc'),
     import('../src/main/rag-ipc'),
-    import('../src/main/llm'),
     import('../src/main/tasks/task-history-ipc')
   ])
-  const service = llm as unknown as { port: number; initialized: boolean; paused: boolean }
-  service.port = fake.port
-  service.initialized = true
-  service.paused = false
   setupIPC()
   setupRagIPC()
   registerTaskHistoryIpc()
@@ -157,6 +152,11 @@ beforeAll(async () => {
   fake = await startFakeLlamaServer()
   await bootProductionMain()
   await import('../src/preload/index')
+  await window.api.setRemoteVisionServer({
+    provider: 'custom',
+    endpoint: `http://127.0.0.1:${fake.port}/v1`,
+    model: 'integration-model'
+  })
   ;({ MemoryChat } = await import('../src/renderer/src/components/MemoryChat'))
   ;({ ProjectsScreen } = await import('../src/renderer/src/components/ProjectsScreen'))
   ;({ TooltipProvider } = await import('../src/renderer/src/components/ui/tooltip'))
@@ -194,7 +194,7 @@ afterAll(async () => {
  *
  * The rail is the <aside> (role complementary), so anything outside it is transcript.
  */
-async function inTranscript(text: string): Promise<HTMLElement> {
+async function inTranscript(text: string | RegExp): Promise<HTMLElement> {
   return waitFor(() => {
     const rail = screen.queryByRole('complementary')
     const shown = screen.getAllByText(text).filter((node) => !rail?.contains(node))
@@ -229,6 +229,63 @@ describe('production workspace bridge', () => {
       ])
     })
     expect(fake.requests).toHaveLength(2)
+  })
+
+  it('shows the real memory-chat failure instead of a fabricated answer', async () => {
+    fake.enqueue(
+      { content: '{"intent":"chat","urls":[]}' },
+      {
+        errorStatus: 503,
+        errorBody: JSON.stringify({ error: { message: 'Memory model is unavailable.' } })
+      }
+    )
+    const user = userEvent.setup()
+    renderChat()
+
+    const composer = await screen.findByPlaceholderText(/^ask /i)
+    await user.click(screen.getByRole('button', { name: 'New chat' }))
+    fireEvent.change(composer, { target: { value: 'What did I work on today?' } })
+    await user.click(screen.getByRole('button', { name: /^send$/i }))
+
+    expect(await inTranscript(/Memory model is unavailable/)).toBeTruthy()
+    expect(screen.queryByText('Sorry, I could not generate a response right now.')).toBeNull()
+  })
+
+  it('shows and saves a compaction notice when the chat reaches 80% of its context', async () => {
+    const longAnswer = `Stored answer ${'A'.repeat(54_000)}`
+    fake.enqueue(
+      { content: '{"intent":"chat","urls":[]}' },
+      { content: longAnswer },
+      { content: '{"intent":"chat","urls":[]}' },
+      { content: 'The next answer still works.' }
+    )
+    const user = userEvent.setup()
+    renderChat()
+
+    const composer = await screen.findByPlaceholderText(/^ask /i)
+    await user.click(screen.getByRole('button', { name: 'New chat' }))
+    fireEvent.change(composer, { target: { value: 'Start a long conversation' } })
+    await user.click(screen.getByRole('button', { name: /^send$/i }))
+    expect(await inTranscript(longAnswer)).toBeTruthy()
+
+    fireEvent.change(composer, { target: { value: 'Continue after the context fills' } })
+    await user.click(screen.getByRole('button', { name: /^send$/i }))
+    expect(await inTranscript('The next answer still works.')).toBeTruthy()
+    expect(
+      await screen.findByText('Compacted conversation to make room for more messages.')
+    ).toBeTruthy()
+    const nextModelRequest = JSON.stringify(fake.requests.at(-1))
+    expect(nextModelRequest).toContain('Earlier chat excerpts')
+    expect(nextModelRequest).not.toContain(longAnswer)
+
+    const { getRagConversations, getRagMessages } = await import('../src/main/database')
+    const conversation = getRagConversations().find(
+      ({ title }) => title === 'Start a long conversation'
+    )
+    expect(conversation).toBeTruthy()
+    expect(getRagMessages(conversation!.id)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ content: '_Compacted_' })])
+    )
   })
 
   it('renders projects, chats, messages, and artifacts after the real database reopens', async () => {

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -4,6 +4,18 @@ set -e
 
 ZERO_OID="0000000000000000000000000000000000000000"
 
+new_branch_base() {
+  local_oid=$1
+  for candidate in "${OFFGRID_PUSH_BASE:-}" origin/release/computer_use origin/main; do
+    [ -z "$candidate" ] && continue
+    if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+      git merge-base "$local_oid" "$candidate"
+      return
+    fi
+  done
+  git rev-list --max-parents=0 "$local_oid" | tail -1
+}
+
 collect_changed_files() {
   if [ -t 0 ]; then
     git diff --name-only --diff-filter=ACMR '@{upstream}..HEAD' 2>/dev/null || true
@@ -15,12 +27,11 @@ collect_changed_files() {
     [ "$local_oid" = "$ZERO_OID" ] && continue
 
     if [ "$remote_oid" = "$ZERO_OID" ]; then
-      # A new branch has no remote tip. Inspect only commits that are not already
-      # reachable from origin instead of assuming the branch started from main.
-      commits=$(git rev-list "$local_oid" --not --remotes=origin 2>/dev/null || true)
-      if [ -n "$commits" ]; then
-        git diff-tree --no-commit-id --name-only -r --diff-filter=ACMR $commits
-      fi
+      # A new branch has no remote tip. Diff its complete range from the release
+      # base. Passing several commits to diff-tree can silently compare trees and
+      # omit earlier commits in the push.
+      base=$(new_branch_base "$local_oid")
+      git diff --name-only --diff-filter=ACMR "$base..$local_oid"
     else
       git diff --name-only --diff-filter=ACMR "$remote_oid..$local_oid"
     fi

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1043,18 +1043,7 @@ export function setupIPC() {
         }
       } catch (e) {
         console.error('[RAG] LLM chat failed:', e)
-        return {
-          answer: 'Sorry, I could not generate a response right now.',
-          context: {
-            masterMemory: null,
-            memories,
-            messages,
-            summaries,
-            entities,
-            entityFacts,
-            unified: unifiedHits
-          }
-        }
+        throw e
       }
     }
   )

--- a/src/renderer/src/components/MemoryChat.tsx
+++ b/src/renderer/src/components/MemoryChat.tsx
@@ -880,6 +880,17 @@ function WebTaskStepFeed(): React.JSX.Element | null {
   )
 }
 
+/** The main process rethrows the real reason; Electron wraps it as "Error invoking remote method". */
+function generationErrorContent(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error ?? '')
+  const message = raw
+    .replace(/^Error invoking remote method '[^']+': (?:Error: )?/, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 800)
+  return message || 'Sorry, something went wrong while generating a response.'
+}
+
 function MessageThinkingHeader({
   message,
   timeline = false
@@ -4275,15 +4286,7 @@ export function MemoryChat({
         return
       }
       console.error('RAG chat failed', e)
-      const errorMessage = e instanceof Error ? e.message : ''
-      const remoteErrorStart = errorMessage.indexOf('Remote text model')
-      const errorContent =
-        remoteErrorStart >= 0
-          ? errorMessage
-              .slice(remoteErrorStart, remoteErrorStart + 800)
-              .replace(/\s+/g, ' ')
-              .trim()
-          : 'Sorry, something went wrong while generating a response.'
+      const errorContent = generationErrorContent(e)
       // Update the streaming placeholder to show the error — never append a second bubble.
       const sid = activeStreamId
       setConvMessages(convId, (prev) => {

--- a/src/renderer/src/components/__tests__/MemoryChat.chat-lifecycle.test.tsx
+++ b/src/renderer/src/components/__tests__/MemoryChat.chat-lifecycle.test.tsx
@@ -855,9 +855,10 @@ describe('<MemoryChat/> - chat lifecycle integration (#36-#42, #47-#48)', () => 
     await waitFor(() => expect(boundary.calls).toHaveLength(1))
     boundary.reject(0, new Error('local model unavailable'))
 
+    expect(await screen.findByText('local model unavailable')).toBeTruthy()
     expect(
-      await screen.findByText('Sorry, something went wrong while generating a response.')
-    ).toBeTruthy()
+      screen.queryByText('Sorry, something went wrong while generating a response.')
+    ).toBeNull()
     await waitFor(() =>
       expect(screen.queryByRole('button', { name: /stop generating/i })).toBeNull()
     )


### PR DESCRIPTION
## Summary
- Surface the real model failure in memory chat instead of a fabricated answer.
- Add UI integration coverage for the failure and 80% context compaction through the production chat, preload, IPC, model service, and SQLite paths.

## Verification
- Focused UI integration suite: 4 passed.
- Typecheck passed; focused test-file lint passed.
- No E2E tests were run.
- Full repository lint still has existing errors.